### PR TITLE
feat(app): transform golang clean-arch to python

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,10 @@ on:
       - "*/.golangci.yml"
       - "*/Makefile"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GOLANGCI_LINT_VERSION: v2.2.1
 

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -1,0 +1,71 @@
+name: Python CI
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'python_src/**'
+      - '.github/workflows/python_ci.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Python Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: 'python_src/pyproject.toml'
+          cache: "poetry"
+
+      - name: Install dependencies
+        working-directory: python_src
+        run: poetry install --no-interaction --no-root
+
+      - name: Run isort
+        working-directory: python_src
+        run: poetry run isort . --check --diff
+
+      - name: Run black
+        working-directory: python_src
+        run: poetry run black . --check --diff
+
+      - name: Run pyright
+        working-directory: python_src
+        run: poetry run pyright
+
+  test:
+    name: Integration test and unit test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: 'python_src/pyproject.toml'
+          cache: "poetry"
+
+      - name: Install dependencies
+        working-directory: python_src
+        run: poetry install --no-interaction --no-root
+
+      - name: Run pytest
+        working-directory: python_src
+        run: poetry run pytest

--- a/python_src/Makefile
+++ b/python_src/Makefile
@@ -12,8 +12,16 @@ help:
 	@echo "  init          - Initialize development environment"
 	@echo "  restart-shell - Restart/reload shell configuration" 
 	@echo "  clean         - Clean up virtual environment"
+	@echo "  test          - Run tests"
 	@echo "  lint          - Run code linting (black, isort, pyright)"
+	@echo "  run           - Run the application (development mode with reload)"
+	@echo "  run-prod      - Run the application (production mode, no reload)"
 	@echo "  help          - Show this help message"
+	@echo ""
+	@echo "Environment variables for run/run-prod:"
+	@echo "  HOST          - Server host (default: 0.0.0.0)"
+	@echo "  PORT          - Server port (default: 8080)"
+	@echo "  LOG_LEVEL     - Log level (default: info)"
 
 # Initialize development environment
 init:
@@ -130,16 +138,42 @@ clean:
 	fi
 
 # Run code linting
-lint:
+fmt:
 	@echo "🔍 Running code linting..."
 	@if command -v poetry &> /dev/null; then \
 		echo "📝 Running black (code formatter)..."; \
-		poetry run black --check --diff .; \
+		poetry run black .; \
 		echo "🔧 Running isort (import sorter)..."; \
-		poetry run isort --check-only --diff .; \
+		poetry run isort .; \
 		echo "🔎 Running pyright (type checker)..."; \
 		poetry run pyright; \
 		echo "✅ All linting checks completed"; \
+	else \
+		echo "❌ Poetry not found in PATH. Please run 'make init' first."; \
+		exit 1; \
+	fi
+
+# Run tests
+test:
+	@echo "🧪 Running tests..."
+	@if command -v poetry &> /dev/null; then \
+		PYTHONPATH=. poetry run pytest -v --tb=short; \
+		echo "✅ Tests completed"; \
+	else \
+		echo "❌ Poetry not found in PATH. Please run 'make init' first."; \
+		exit 1; \
+	fi
+
+
+# Run the application
+run:
+	@echo "🚀 Running application..."
+	@if command -v poetry &> /dev/null; then \
+		PYTHONPATH=. poetry run uvicorn entrypoint.app.http_server:app \
+			--host=$${HOST:-0.0.0.0} \
+			--port=$${PORT:-8080} \
+			--reload \
+			--log-level=$${LOG_LEVEL:-info}; \
 	else \
 		echo "❌ Poetry not found in PATH. Please run 'make init' first."; \
 		exit 1; \

--- a/python_src/entrypoint/__init__.py
+++ b/python_src/entrypoint/__init__.py
@@ -1,0 +1,1 @@
+# Command line interface package

--- a/python_src/entrypoint/app/__init__.py
+++ b/python_src/entrypoint/app/__init__.py
@@ -1,0 +1,1 @@
+# Main application entry point package

--- a/python_src/entrypoint/app/http_server.py
+++ b/python_src/entrypoint/app/http_server.py
@@ -1,0 +1,50 @@
+"""HTTP server setup and configuration."""
+
+import structlog
+from fastapi import FastAPI
+
+from internal.router.handlers import create_api_router
+from internal.router.middleware import LoggingMiddleware, RequestIDMiddleware
+
+
+def configure_logging() -> structlog.BoundLogger:
+    """Configure structured logging for the application."""
+    # Configure structlog
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.dev.ConsoleRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(20),  # INFO level
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    # Create root logger
+    logger = structlog.get_logger()
+    return logger.bind(service="workshop", env="production")
+
+
+def create_app(logger: structlog.BoundLogger | None = None) -> FastAPI:
+    """Create and configure FastAPI application."""
+    if logger is None:
+        logger = configure_logging()
+
+    app = FastAPI(title="Workshop API", version="1.0.0", docs_url="/docs", redoc_url="/redoc")
+
+    # Add middleware (order matters - first added is outermost)
+    app.add_middleware(LoggingMiddleware, logger=logger)
+    app.add_middleware(RequestIDMiddleware)
+
+    # Add API routes
+    api_router = create_api_router()
+    app.include_router(api_router)
+
+    return app
+
+
+app = create_app()

--- a/python_src/entrypoint/app/settings.py
+++ b/python_src/entrypoint/app/settings.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AppConfig(BaseSettings):
+    """Application configuration using pydantic-settings."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="WORKSHOP_", env_file=".env", env_file_encoding="utf-8", case_sensitive=False
+    )
+
+    env: Literal["local", "staging", "production"] = Field(default="staging", description="The running environment")
+
+    log_level: Literal["error", "warn", "info", "debug", "disabled"] = Field(
+        default="info", description="Log filtering level"
+    )
+
+    port: int = Field(default=8080, description="The HTTP server port", ge=1, le=65535)

--- a/python_src/env.example
+++ b/python_src/env.example
@@ -1,0 +1,11 @@
+# Workshop Application Configuration
+# Copy this file to .env and adjust values as needed
+
+# Runtime environment: local, staging, production
+WORKSHOP_ENV=local
+
+# Log level: error, warn, info, debug, disabled
+WORKSHOP_LOG_LEVEL=debug
+
+# HTTP server port (1-65535)
+WORKSHOP_PORT=8080 

--- a/python_src/internal/__init__.py
+++ b/python_src/internal/__init__.py
@@ -1,0 +1,1 @@
+# Internal application packages

--- a/python_src/internal/domain/__init__.py
+++ b/python_src/internal/domain/__init__.py
@@ -1,0 +1,1 @@
+# Domain layer package

--- a/python_src/internal/domain/common/__init__.py
+++ b/python_src/internal/domain/common/__init__.py
@@ -1,0 +1,1 @@
+# Common domain utilities and error handling

--- a/python_src/internal/domain/common/error.py
+++ b/python_src/internal/domain/common/error.py
@@ -1,0 +1,90 @@
+"""Domain error handling classes and utilities."""
+
+from typing import Any, Protocol
+
+from internal.domain.common.error_code import ErrorCode
+
+
+class Error(Protocol):
+    """Protocol defining the interface for domain errors."""
+
+    def __str__(self) -> str:
+        """Return error message."""
+        ...
+
+    def name(self) -> str:
+        """Return error name."""
+        ...
+
+    def client_msg(self) -> str:
+        """Return client-facing message."""
+        ...
+
+
+class DomainError(Exception):
+    """Domain error used for expressing errors occurring in application."""
+
+    def __init__(
+        self,
+        code: ErrorCode,
+        err: Exception | None = None,
+        client_msg: str = "",
+        remote_status: int = 0,
+        detail: dict[str, Any] | None = None,
+    ):
+        self.code = code
+        self.err = err
+        self._client_msg = client_msg
+        self.remote_status = remote_status
+        self.detail = detail or {}
+        super().__init__(self._build_message())
+
+    def _build_message(self) -> str:
+        """Build error message from components."""
+        msgs = []
+
+        if self.remote_status != 0:
+            msgs.append(str(self.remote_status))
+
+        if self.err is not None:
+            msgs.append(str(self.err))
+
+        if self._client_msg:
+            msgs.append(self._client_msg)
+
+        return ": ".join(msgs)
+
+    def name(self) -> str:
+        """Return error name."""
+        if not self.code.name:
+            return "UNKNOWN_ERROR"
+        return self.code.name
+
+    def client_msg(self) -> str:
+        """Return client-facing message."""
+        return self._client_msg
+
+    def http_status(self) -> int:
+        """Return HTTP status code."""
+        if self.code.status_code == 0:
+            return 500
+        return self.code.status_code
+
+    def remote_http_status(self) -> int:
+        """Return remote HTTP status code."""
+        return self.remote_status
+
+    def get_detail(self) -> dict[str, Any]:
+        """Return error detail."""
+        return self.detail
+
+
+def new_error(
+    code: ErrorCode,
+    err: Exception | None = None,
+    client_msg: str = "",
+    remote_status: int = 0,
+    detail: dict[str, Any] | None = None,
+) -> DomainError:
+    """Create a new domain error."""
+    return DomainError(code=code, err=err, client_msg=client_msg, remote_status=remote_status, detail=detail)

--- a/python_src/internal/domain/common/error_code.py
+++ b/python_src/internal/domain/common/error_code.py
@@ -1,0 +1,23 @@
+"""Error code definitions for domain errors."""
+
+from http import HTTPStatus
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ErrorCode(BaseModel):
+    """Defines an error code with name and HTTP status."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    status_code: int = HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+# Common error codes
+UNKNOWN_ERROR = ErrorCode(name="UNKNOWN_ERROR", status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+VALIDATION_ERROR = ErrorCode(name="VALIDATION_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+NOT_FOUND = ErrorCode(name="NOT_FOUND", status_code=HTTPStatus.NOT_FOUND)
+UNAUTHORIZED = ErrorCode(name="UNAUTHORIZED", status_code=HTTPStatus.UNAUTHORIZED)
+FORBIDDEN = ErrorCode(name="FORBIDDEN", status_code=HTTPStatus.FORBIDDEN)
+INTERNAL_ERROR = ErrorCode(name="INTERNAL_ERROR", status_code=HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/python_src/internal/domain/common/requestid.py
+++ b/python_src/internal/domain/common/requestid.py
@@ -1,0 +1,31 @@
+"""Request ID management utilities."""
+
+import uuid
+from contextvars import ContextVar
+
+# Context variable to store request ID
+_request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+def new_request_id() -> str:
+    """Generate a new request ID."""
+    return str(uuid.uuid4())
+
+
+def set_request_id(request_id: str) -> None:
+    """Set request ID in current context."""
+    _request_id_var.set(request_id)
+
+
+def get_request_id() -> str:
+    """Get request ID from current context."""
+    return _request_id_var.get()
+
+
+def get_request_id_or_new() -> str:
+    """Get request ID from context or generate a new one."""
+    request_id = get_request_id()
+    if not request_id:
+        request_id = new_request_id()
+        set_request_id(request_id)
+    return request_id

--- a/python_src/internal/router/__init__.py
+++ b/python_src/internal/router/__init__.py
@@ -1,0 +1,1 @@
+# HTTP routing and middleware package

--- a/python_src/internal/router/handlers.py
+++ b/python_src/internal/router/handlers.py
@@ -1,0 +1,37 @@
+"""HTTP route handlers for the application."""
+
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
+
+from entrypoint.app.settings import AppConfig
+from internal.domain.common.requestid import get_request_id_or_new
+
+# Global config instance for health check
+_config = AppConfig()
+
+
+def create_api_router() -> APIRouter:
+    """Create and configure the API router with all endpoints."""
+    router = APIRouter(prefix="/api")
+
+    # Create v1 router
+    v1_router = APIRouter(prefix="/v1")
+
+    # Add health check endpoint
+    v1_router.add_api_route(
+        "/health", health_check, methods=["GET"], status_code=status.HTTP_200_OK, response_class=JSONResponse
+    )
+
+    # Include v1 router in main router
+    router.include_router(v1_router)
+
+    return router
+
+
+async def health_check() -> JSONResponse:
+    """Health check endpoint."""
+    request_id = get_request_id_or_new()
+
+    response_data = {"status": "healthy", "env": _config.env, "request_id": request_id}
+
+    return JSONResponse(content=response_data, status_code=status.HTTP_200_OK)

--- a/python_src/internal/router/middleware.py
+++ b/python_src/internal/router/middleware.py
@@ -1,0 +1,90 @@
+"""HTTP middleware for request processing."""
+
+import time
+from collections.abc import Callable
+
+import structlog
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+from internal.domain.common.requestid import get_request_id, new_request_id, set_request_id
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Middleware for managing request IDs."""
+
+    HEADER_X_REQUEST_ID = "X-Request-ID"
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        # Get or generate request ID
+        request_id = request.headers.get(self.HEADER_X_REQUEST_ID, "")
+        if not request_id:
+            request_id = new_request_id()
+
+        # Set request ID in context
+        set_request_id(request_id)
+
+        # Process request
+        response = await call_next(request)
+
+        # Add request ID to response headers
+        response.headers[self.HEADER_X_REQUEST_ID] = request_id
+
+        return response
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware for request/response logging."""
+
+    def __init__(self, app: ASGIApp, logger: structlog.BoundLogger):
+        super().__init__(app)
+        self.logger = logger
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        start_time = time.time()
+
+        # Skip health check to avoid polluting logs
+        if request.url.path == "/api/v1/health":
+            return await call_next(request)
+
+        # Get request ID for logging context
+        request_id = get_request_id()
+
+        # Create request logger with context
+        log = self.logger.bind(requestID=request_id, path=request.url.path, method=request.method, component="router")
+
+        try:
+            # Process request
+            response = await call_next(request)
+
+            # Calculate latency
+            latency = time.time() - start_time
+
+            # Log successful request
+            log.info(
+                "Request processed",
+                status=response.status_code,
+                latency=f"{latency:.6f}s",
+                clientIP=request.client.host if request.client else "unknown",
+                fullPath=str(request.url),
+                userAgent=request.headers.get("User-Agent", ""),
+            )
+
+            return response
+
+        except Exception as e:
+            # Calculate latency
+            latency = time.time() - start_time
+
+            # Log error
+            log.error(
+                "Request failed",
+                error=str(e),
+                latency=f"{latency:.6f}s",
+                clientIP=request.client.host if request.client else "unknown",
+                fullPath=str(request.url),
+                userAgent=request.headers.get("User-Agent", ""),
+            )
+
+            raise

--- a/python_src/poetry.lock
+++ b/python_src/poetry.lock
@@ -13,6 +13,28 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
+    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1) ; python_version >= \"3.10\"", "uvloop (>=0.21) ; platform_python_implementation == \"CPython\" and platform_system != \"Windows\" and python_version < \"3.14\""]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "black"
 version = "25.1.0"
 description = "The uncompromising code formatter."
@@ -58,12 +80,24 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "certifi"
+version = "2025.6.15"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
+    {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
     {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
@@ -78,12 +112,163 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
-markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
+groups = ["main", "dev"]
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "fastapi"
+version = "0.115.14"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca"},
+    {file = "fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739"},
+]
+
+[package.dependencies]
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+starlette = ">=0.40.0,<0.47.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httptools"
+version = "0.6.4"
+description = "A collection of framework independent HTTP protocol utils."
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+files = [
+    {file = "httptools-0.6.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3c73ce323711a6ffb0d247dcd5a550b8babf0f757e86a52558fe5b86d6fefcc0"},
+    {file = "httptools-0.6.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:345c288418f0944a6fe67be8e6afa9262b18c7626c3ef3c28adc5eabc06a68da"},
+    {file = "httptools-0.6.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:deee0e3343f98ee8047e9f4c5bc7cedbf69f5734454a94c38ee829fb2d5fa3c1"},
+    {file = "httptools-0.6.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca80b7485c76f768a3bc83ea58373f8db7b015551117375e4918e2aa77ea9b50"},
+    {file = "httptools-0.6.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:90d96a385fa941283ebd231464045187a31ad932ebfa541be8edf5b3c2328959"},
+    {file = "httptools-0.6.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:59e724f8b332319e2875efd360e61ac07f33b492889284a3e05e6d13746876f4"},
+    {file = "httptools-0.6.4-cp310-cp310-win_amd64.whl", hash = "sha256:c26f313951f6e26147833fc923f78f95604bbec812a43e5ee37f26dc9e5a686c"},
+    {file = "httptools-0.6.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f47f8ed67cc0ff862b84a1189831d1d33c963fb3ce1ee0c65d3b0cbe7b711069"},
+    {file = "httptools-0.6.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0614154d5454c21b6410fdf5262b4a3ddb0f53f1e1721cfd59d55f32138c578a"},
+    {file = "httptools-0.6.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8787367fbdfccae38e35abf7641dafc5310310a5987b689f4c32cc8cc3ee975"},
+    {file = "httptools-0.6.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40b0f7fe4fd38e6a507bdb751db0379df1e99120c65fbdc8ee6c1d044897a636"},
+    {file = "httptools-0.6.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40a5ec98d3f49904b9fe36827dcf1aadfef3b89e2bd05b0e35e94f97c2b14721"},
+    {file = "httptools-0.6.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dacdd3d10ea1b4ca9df97a0a303cbacafc04b5cd375fa98732678151643d4988"},
+    {file = "httptools-0.6.4-cp311-cp311-win_amd64.whl", hash = "sha256:288cd628406cc53f9a541cfaf06041b4c71d751856bab45e3702191f931ccd17"},
+    {file = "httptools-0.6.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:df017d6c780287d5c80601dafa31f17bddb170232d85c066604d8558683711a2"},
+    {file = "httptools-0.6.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:85071a1e8c2d051b507161f6c3e26155b5c790e4e28d7f236422dbacc2a9cc44"},
+    {file = "httptools-0.6.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69422b7f458c5af875922cdb5bd586cc1f1033295aa9ff63ee196a87519ac8e1"},
+    {file = "httptools-0.6.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16e603a3bff50db08cd578d54f07032ca1631450ceb972c2f834c2b860c28ea2"},
+    {file = "httptools-0.6.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec4f178901fa1834d4a060320d2f3abc5c9e39766953d038f1458cb885f47e81"},
+    {file = "httptools-0.6.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f9eb89ecf8b290f2e293325c646a211ff1c2493222798bb80a530c5e7502494f"},
+    {file = "httptools-0.6.4-cp312-cp312-win_amd64.whl", hash = "sha256:db78cb9ca56b59b016e64b6031eda5653be0589dba2b1b43453f6e8b405a0970"},
+    {file = "httptools-0.6.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ade273d7e767d5fae13fa637f4d53b6e961fb7fd93c7797562663f0171c26660"},
+    {file = "httptools-0.6.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:856f4bc0478ae143bad54a4242fccb1f3f86a6e1be5548fecfd4102061b3a083"},
+    {file = "httptools-0.6.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:322d20ea9cdd1fa98bd6a74b77e2ec5b818abdc3d36695ab402a0de8ef2865a3"},
+    {file = "httptools-0.6.4-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d87b29bd4486c0093fc64dea80231f7c7f7eb4dc70ae394d70a495ab8436071"},
+    {file = "httptools-0.6.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:342dd6946aa6bda4b8f18c734576106b8a31f2fe31492881a9a160ec84ff4bd5"},
+    {file = "httptools-0.6.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b36913ba52008249223042dca46e69967985fb4051951f94357ea681e1f5dc0"},
+    {file = "httptools-0.6.4-cp313-cp313-win_amd64.whl", hash = "sha256:28908df1b9bb8187393d5b5db91435ccc9c8e891657f9cbb42a2541b44c82fc8"},
+    {file = "httptools-0.6.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d3f0d369e7ffbe59c4b6116a44d6a8eb4783aae027f2c0b366cf0aa964185dba"},
+    {file = "httptools-0.6.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:94978a49b8f4569ad607cd4946b759d90b285e39c0d4640c6b36ca7a3ddf2efc"},
+    {file = "httptools-0.6.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40dc6a8e399e15ea525305a2ddba998b0af5caa2566bcd79dcbe8948181eeaff"},
+    {file = "httptools-0.6.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab9ba8dcf59de5181f6be44a77458e45a578fc99c31510b8c65b7d5acc3cf490"},
+    {file = "httptools-0.6.4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:fc411e1c0a7dcd2f902c7c48cf079947a7e65b5485dea9decb82b9105ca71a43"},
+    {file = "httptools-0.6.4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:d54efd20338ac52ba31e7da78e4a72570cf729fac82bc31ff9199bedf1dc7440"},
+    {file = "httptools-0.6.4-cp38-cp38-win_amd64.whl", hash = "sha256:df959752a0c2748a65ab5387d08287abf6779ae9165916fe053e68ae1fbdc47f"},
+    {file = "httptools-0.6.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:85797e37e8eeaa5439d33e556662cc370e474445d5fab24dcadc65a8ffb04003"},
+    {file = "httptools-0.6.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:db353d22843cf1028f43c3651581e4bb49374d85692a85f95f7b9a130e1b2cab"},
+    {file = "httptools-0.6.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1ffd262a73d7c28424252381a5b854c19d9de5f56f075445d33919a637e3547"},
+    {file = "httptools-0.6.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:703c346571fa50d2e9856a37d7cd9435a25e7fd15e236c397bf224afaa355fe9"},
+    {file = "httptools-0.6.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:aafe0f1918ed07b67c1e838f950b1c1fabc683030477e60b335649b8020e1076"},
+    {file = "httptools-0.6.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0e563e54979e97b6d13f1bbc05a96109923e76b901f786a5eae36e99c01237bd"},
+    {file = "httptools-0.6.4-cp39-cp39-win_amd64.whl", hash = "sha256:b799de31416ecc589ad79dd85a0b2657a8fe39327944998dea368c1d4c9e55e6"},
+    {file = "httptools-0.6.4.tar.gz", hash = "sha256:4e93eee4add6493b59a5c514da98c939b244fce4a0d8879cd3f466562f4b7d5c"},
+]
+
+[package.extras]
+test = ["Cython (>=0.29.24)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "idna"
+version = "3.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -329,6 +514,30 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.10.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796"},
+    {file = "pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "boto3-stubs[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -406,6 +615,21 @@ colorama = ["colorama"]
 termcolor = ["termcolor"]
 
 [[package]]
+name = "python-dotenv"
+version = "1.1.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
+    {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
@@ -415,6 +639,111 @@ groups = ["main"]
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "starlette"
+version = "0.46.2"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35"},
+    {file = "starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
+name = "structlog"
+version = "25.4.0"
+description = "Structured Logging for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "structlog-25.4.0-py3-none-any.whl", hash = "sha256:fe809ff5c27e557d14e613f45ca441aabda051d119ee5a0102aaba6ce40eed2c"},
+    {file = "structlog-25.4.0.tar.gz", hash = "sha256:186cd1b0a8ae762e29417095664adf1d6a31702160a46dacb7796ea82f7409e4"},
 ]
 
 [[package]]
@@ -444,7 +773,284 @@ files = [
 [package.dependencies]
 typing-extensions = ">=4.12.0"
 
+[[package]]
+name = "uvicorn"
+version = "0.35.0"
+description = "The lightning-fast ASGI server."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a"},
+    {file = "uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+colorama = {version = ">=0.4", optional = true, markers = "sys_platform == \"win32\" and extra == \"standard\""}
+h11 = ">=0.8"
+httptools = {version = ">=0.6.3", optional = true, markers = "extra == \"standard\""}
+python-dotenv = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
+pyyaml = {version = ">=5.1", optional = true, markers = "extra == \"standard\""}
+uvloop = {version = ">=0.15.1", optional = true, markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and extra == \"standard\""}
+watchfiles = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
+websockets = {version = ">=10.4", optional = true, markers = "extra == \"standard\""}
+
+[package.extras]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+
+[[package]]
+name = "uvloop"
+version = "0.21.0"
+description = "Fast implementation of asyncio event loop on top of libuv"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\""
+files = [
+    {file = "uvloop-0.21.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ec7e6b09a6fdded42403182ab6b832b71f4edaf7f37a9a0e371a01db5f0cb45f"},
+    {file = "uvloop-0.21.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:196274f2adb9689a289ad7d65700d37df0c0930fd8e4e743fa4834e850d7719d"},
+    {file = "uvloop-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f38b2e090258d051d68a5b14d1da7203a3c3677321cf32a95a6f4db4dd8b6f26"},
+    {file = "uvloop-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87c43e0f13022b998eb9b973b5e97200c8b90823454d4bc06ab33829e09fb9bb"},
+    {file = "uvloop-0.21.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:10d66943def5fcb6e7b37310eb6b5639fd2ccbc38df1177262b0640c3ca68c1f"},
+    {file = "uvloop-0.21.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:67dd654b8ca23aed0a8e99010b4c34aca62f4b7fce88f39d452ed7622c94845c"},
+    {file = "uvloop-0.21.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c0f3fa6200b3108919f8bdabb9a7f87f20e7097ea3c543754cabc7d717d95cf8"},
+    {file = "uvloop-0.21.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0878c2640cf341b269b7e128b1a5fed890adc4455513ca710d77d5e93aa6d6a0"},
+    {file = "uvloop-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9fb766bb57b7388745d8bcc53a359b116b8a04c83a2288069809d2b3466c37e"},
+    {file = "uvloop-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a375441696e2eda1c43c44ccb66e04d61ceeffcd76e4929e527b7fa401b90fb"},
+    {file = "uvloop-0.21.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:baa0e6291d91649c6ba4ed4b2f982f9fa165b5bbd50a9e203c416a2797bab3c6"},
+    {file = "uvloop-0.21.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4509360fcc4c3bd2c70d87573ad472de40c13387f5fda8cb58350a1d7475e58d"},
+    {file = "uvloop-0.21.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:359ec2c888397b9e592a889c4d72ba3d6befba8b2bb01743f72fffbde663b59c"},
+    {file = "uvloop-0.21.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f7089d2dc73179ce5ac255bdf37c236a9f914b264825fdaacaded6990a7fb4c2"},
+    {file = "uvloop-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baa4dcdbd9ae0a372f2167a207cd98c9f9a1ea1188a8a526431eef2f8116cc8d"},
+    {file = "uvloop-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86975dca1c773a2c9864f4c52c5a55631038e387b47eaf56210f873887b6c8dc"},
+    {file = "uvloop-0.21.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:461d9ae6660fbbafedd07559c6a2e57cd553b34b0065b6550685f6653a98c1cb"},
+    {file = "uvloop-0.21.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:183aef7c8730e54c9a3ee3227464daed66e37ba13040bb3f350bc2ddc040f22f"},
+    {file = "uvloop-0.21.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bfd55dfcc2a512316e65f16e503e9e450cab148ef11df4e4e679b5e8253a5281"},
+    {file = "uvloop-0.21.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787ae31ad8a2856fc4e7c095341cccc7209bd657d0e71ad0dc2ea83c4a6fa8af"},
+    {file = "uvloop-0.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ee4d4ef48036ff6e5cfffb09dd192c7a5027153948d85b8da7ff705065bacc6"},
+    {file = "uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816"},
+    {file = "uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc"},
+    {file = "uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553"},
+    {file = "uvloop-0.21.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:17df489689befc72c39a08359efac29bbee8eee5209650d4b9f34df73d22e414"},
+    {file = "uvloop-0.21.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bc09f0ff191e61c2d592a752423c767b4ebb2986daa9ed62908e2b1b9a9ae206"},
+    {file = "uvloop-0.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0ce1b49560b1d2d8a2977e3ba4afb2414fb46b86a1b64056bc4ab929efdafbe"},
+    {file = "uvloop-0.21.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e678ad6fe52af2c58d2ae3c73dc85524ba8abe637f134bf3564ed07f555c5e79"},
+    {file = "uvloop-0.21.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:460def4412e473896ef179a1671b40c039c7012184b627898eea5072ef6f017a"},
+    {file = "uvloop-0.21.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:10da8046cc4a8f12c91a1c39d1dd1585c41162a15caaef165c2174db9ef18bdc"},
+    {file = "uvloop-0.21.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c097078b8031190c934ed0ebfee8cc5f9ba9642e6eb88322b9958b649750f72b"},
+    {file = "uvloop-0.21.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:46923b0b5ee7fc0020bef24afe7836cb068f5050ca04caf6b487c513dc1a20b2"},
+    {file = "uvloop-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53e420a3afe22cdcf2a0f4846e377d16e718bc70103d7088a4f7623567ba5fb0"},
+    {file = "uvloop-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88cb67cdbc0e483da00af0b2c3cdad4b7c61ceb1ee0f33fe00e09c81e3a6cb75"},
+    {file = "uvloop-0.21.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:221f4f2a1f46032b403bf3be628011caf75428ee3cc204a22addf96f586b19fd"},
+    {file = "uvloop-0.21.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2d1f581393673ce119355d56da84fe1dd9d2bb8b3d13ce792524e1607139feff"},
+    {file = "uvloop-0.21.0.tar.gz", hash = "sha256:3bf12b0fda68447806a7ad847bfa591613177275d35b6724b1ee573faa3704e3"},
+]
+
+[package.extras]
+dev = ["Cython (>=3.0,<4.0)", "setuptools (>=60)"]
+docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)"]
+test = ["aiohttp (>=3.10.5)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=23.0.0,<23.1.0)", "pycodestyle (>=2.9.0,<2.10.0)"]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.0"
+description = "Simple, modern and high performance file watching and code reload in python."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "watchfiles-1.1.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:27f30e14aa1c1e91cb653f03a63445739919aef84c8d2517997a83155e7a2fcc"},
+    {file = "watchfiles-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3366f56c272232860ab45c77c3ca7b74ee819c8e1f6f35a7125556b198bbc6df"},
+    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8412eacef34cae2836d891836a7fff7b754d6bcac61f6c12ba5ca9bc7e427b68"},
+    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df670918eb7dd719642e05979fc84704af913d563fd17ed636f7c4783003fdcc"},
+    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d7642b9bc4827b5518ebdb3b82698ada8c14c7661ddec5fe719f3e56ccd13c97"},
+    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:199207b2d3eeaeb80ef4411875a6243d9ad8bc35b07fc42daa6b801cc39cc41c"},
+    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a479466da6db5c1e8754caee6c262cd373e6e6c363172d74394f4bff3d84d7b5"},
+    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:935f9edd022ec13e447e5723a7d14456c8af254544cefbc533f6dd276c9aa0d9"},
+    {file = "watchfiles-1.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8076a5769d6bdf5f673a19d51da05fc79e2bbf25e9fe755c47595785c06a8c72"},
+    {file = "watchfiles-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:86b1e28d4c37e89220e924305cd9f82866bb0ace666943a6e4196c5df4d58dcc"},
+    {file = "watchfiles-1.1.0-cp310-cp310-win32.whl", hash = "sha256:d1caf40c1c657b27858f9774d5c0e232089bca9cb8ee17ce7478c6e9264d2587"},
+    {file = "watchfiles-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:a89c75a5b9bc329131115a409d0acc16e8da8dfd5867ba59f1dd66ae7ea8fa82"},
+    {file = "watchfiles-1.1.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c9649dfc57cc1f9835551deb17689e8d44666315f2e82d337b9f07bd76ae3aa2"},
+    {file = "watchfiles-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:406520216186b99374cdb58bc48e34bb74535adec160c8459894884c983a149c"},
+    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb45350fd1dc75cd68d3d72c47f5b513cb0578da716df5fba02fff31c69d5f2d"},
+    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11ee4444250fcbeb47459a877e5e80ed994ce8e8d20283857fc128be1715dac7"},
+    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bda8136e6a80bdea23e5e74e09df0362744d24ffb8cd59c4a95a6ce3d142f79c"},
+    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b915daeb2d8c1f5cee4b970f2e2c988ce6514aace3c9296e58dd64dc9aa5d575"},
+    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed8fc66786de8d0376f9f913c09e963c66e90ced9aa11997f93bdb30f7c872a8"},
+    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe4371595edf78c41ef8ac8df20df3943e13defd0efcb732b2e393b5a8a7a71f"},
+    {file = "watchfiles-1.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b7c5f6fe273291f4d414d55b2c80d33c457b8a42677ad14b4b47ff025d0893e4"},
+    {file = "watchfiles-1.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7738027989881e70e3723c75921f1efa45225084228788fc59ea8c6d732eb30d"},
+    {file = "watchfiles-1.1.0-cp311-cp311-win32.whl", hash = "sha256:622d6b2c06be19f6e89b1d951485a232e3b59618def88dbeda575ed8f0d8dbf2"},
+    {file = "watchfiles-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:48aa25e5992b61debc908a61ab4d3f216b64f44fdaa71eb082d8b2de846b7d12"},
+    {file = "watchfiles-1.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:00645eb79a3faa70d9cb15c8d4187bb72970b2470e938670240c7998dad9f13a"},
+    {file = "watchfiles-1.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9dc001c3e10de4725c749d4c2f2bdc6ae24de5a88a339c4bce32300a31ede179"},
+    {file = "watchfiles-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9ba68ec283153dead62cbe81872d28e053745f12335d037de9cbd14bd1877f5"},
+    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:130fc497b8ee68dce163e4254d9b0356411d1490e868bd8790028bc46c5cc297"},
+    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50a51a90610d0845a5931a780d8e51d7bd7f309ebc25132ba975aca016b576a0"},
+    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc44678a72ac0910bac46fa6a0de6af9ba1355669b3dfaf1ce5f05ca7a74364e"},
+    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a543492513a93b001975ae283a51f4b67973662a375a403ae82f420d2c7205ee"},
+    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ac164e20d17cc285f2b94dc31c384bc3aa3dd5e7490473b3db043dd70fbccfd"},
+    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7590d5a455321e53857892ab8879dce62d1f4b04748769f5adf2e707afb9d4f"},
+    {file = "watchfiles-1.1.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:37d3d3f7defb13f62ece99e9be912afe9dd8a0077b7c45ee5a57c74811d581a4"},
+    {file = "watchfiles-1.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:7080c4bb3efd70a07b1cc2df99a7aa51d98685be56be6038c3169199d0a1c69f"},
+    {file = "watchfiles-1.1.0-cp312-cp312-win32.whl", hash = "sha256:cbcf8630ef4afb05dc30107bfa17f16c0896bb30ee48fc24bf64c1f970f3b1fd"},
+    {file = "watchfiles-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:cbd949bdd87567b0ad183d7676feb98136cde5bb9025403794a4c0db28ed3a47"},
+    {file = "watchfiles-1.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:0a7d40b77f07be87c6faa93d0951a0fcd8cbca1ddff60a1b65d741bac6f3a9f6"},
+    {file = "watchfiles-1.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5007f860c7f1f8df471e4e04aaa8c43673429047d63205d1630880f7637bca30"},
+    {file = "watchfiles-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:20ecc8abbd957046f1fe9562757903f5eaf57c3bce70929fda6c7711bb58074a"},
+    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2f0498b7d2a3c072766dba3274fe22a183dbea1f99d188f1c6c72209a1063dc"},
+    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:239736577e848678e13b201bba14e89718f5c2133dfd6b1f7846fa1b58a8532b"},
+    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eff4b8d89f444f7e49136dc695599a591ff769300734446c0a86cba2eb2f9895"},
+    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12b0a02a91762c08f7264e2e79542f76870c3040bbc847fb67410ab81474932a"},
+    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:29e7bc2eee15cbb339c68445959108803dc14ee0c7b4eea556400131a8de462b"},
+    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9481174d3ed982e269c090f780122fb59cee6c3796f74efe74e70f7780ed94c"},
+    {file = "watchfiles-1.1.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:80f811146831c8c86ab17b640801c25dc0a88c630e855e2bef3568f30434d52b"},
+    {file = "watchfiles-1.1.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:60022527e71d1d1fda67a33150ee42869042bce3d0fcc9cc49be009a9cded3fb"},
+    {file = "watchfiles-1.1.0-cp313-cp313-win32.whl", hash = "sha256:32d6d4e583593cb8576e129879ea0991660b935177c0f93c6681359b3654bfa9"},
+    {file = "watchfiles-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:f21af781a4a6fbad54f03c598ab620e3a77032c5878f3d780448421a6e1818c7"},
+    {file = "watchfiles-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:5366164391873ed76bfdf618818c82084c9db7fac82b64a20c44d335eec9ced5"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:17ab167cca6339c2b830b744eaf10803d2a5b6683be4d79d8475d88b4a8a4be1"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:328dbc9bff7205c215a7807da7c18dce37da7da718e798356212d22696404339"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7208ab6e009c627b7557ce55c465c98967e8caa8b11833531fdf95799372633"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a8f6f72974a19efead54195bc9bed4d850fc047bb7aa971268fd9a8387c89011"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d181ef50923c29cf0450c3cd47e2f0557b62218c50b2ab8ce2ecaa02bd97e670"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:adb4167043d3a78280d5d05ce0ba22055c266cf8655ce942f2fb881262ff3cdf"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5701dc474b041e2934a26d31d39f90fac8a3dee2322b39f7729867f932b1d4"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b067915e3c3936966a8607f6fe5487df0c9c4afb85226613b520890049deea20"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:9c733cda03b6d636b4219625a4acb5c6ffb10803338e437fb614fef9516825ef"},
+    {file = "watchfiles-1.1.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:cc08ef8b90d78bfac66f0def80240b0197008e4852c9f285907377b2947ffdcb"},
+    {file = "watchfiles-1.1.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9974d2f7dc561cce3bb88dfa8eb309dab64c729de85fba32e98d75cf24b66297"},
+    {file = "watchfiles-1.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c68e9f1fcb4d43798ad8814c4c1b61547b014b667216cb754e606bfade587018"},
+    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95ab1594377effac17110e1352989bdd7bdfca9ff0e5eeccd8c69c5389b826d0"},
+    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fba9b62da882c1be1280a7584ec4515d0a6006a94d6e5819730ec2eab60ffe12"},
+    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3434e401f3ce0ed6b42569128b3d1e3af773d7ec18751b918b89cd49c14eaafb"},
+    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fa257a4d0d21fcbca5b5fcba9dca5a78011cb93c0323fb8855c6d2dfbc76eb77"},
+    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fd1b3879a578a8ec2076c7961076df540b9af317123f84569f5a9ddee64ce92"},
+    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62cc7a30eeb0e20ecc5f4bd113cd69dcdb745a07c68c0370cea919f373f65d9e"},
+    {file = "watchfiles-1.1.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:891c69e027748b4a73847335d208e374ce54ca3c335907d381fde4e41661b13b"},
+    {file = "watchfiles-1.1.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:12fe8eaffaf0faa7906895b4f8bb88264035b3f0243275e0bf24af0436b27259"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:bfe3c517c283e484843cb2e357dd57ba009cff351edf45fb455b5fbd1f45b15f"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9ccbf1f129480ed3044f540c0fdbc4ee556f7175e5ab40fe077ff6baf286d4e"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba0e3255b0396cac3cc7bbace76404dd72b5438bf0d8e7cefa2f79a7f3649caa"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4281cd9fce9fc0a9dbf0fc1217f39bf9cf2b4d315d9626ef1d4e87b84699e7e8"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d2404af8db1329f9a3c9b79ff63e0ae7131986446901582067d9304ae8aaf7f"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e78b6ed8165996013165eeabd875c5dfc19d41b54f94b40e9fff0eb3193e5e8e"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:249590eb75ccc117f488e2fabd1bfa33c580e24b96f00658ad88e38844a040bb"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d05686b5487cfa2e2c28ff1aa370ea3e6c5accfe6435944ddea1e10d93872147"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d0e10e6f8f6dc5762adee7dece33b722282e1f59aa6a55da5d493a97282fedd8"},
+    {file = "watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:af06c863f152005c7592df1d6a7009c836a247c9d8adb78fef8575a5a98699db"},
+    {file = "watchfiles-1.1.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:865c8e95713744cf5ae261f3067861e9da5f1370ba91fc536431e29b418676fa"},
+    {file = "watchfiles-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42f92befc848bb7a19658f21f3e7bae80d7d005d13891c62c2cd4d4d0abb3433"},
+    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa0cc8365ab29487eb4f9979fd41b22549853389e22d5de3f134a6796e1b05a4"},
+    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:90ebb429e933645f3da534c89b29b665e285048973b4d2b6946526888c3eb2c7"},
+    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c588c45da9b08ab3da81d08d7987dae6d2a3badd63acdb3e206a42dbfa7cb76f"},
+    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c55b0f9f68590115c25272b06e63f0824f03d4fc7d6deed43d8ad5660cabdbf"},
+    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd17a1e489f02ce9117b0de3c0b1fab1c3e2eedc82311b299ee6b6faf6c23a29"},
+    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da71945c9ace018d8634822f16cbc2a78323ef6c876b1d34bbf5d5222fd6a72e"},
+    {file = "watchfiles-1.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:51556d5004887045dba3acdd1fdf61dddea2be0a7e18048b5e853dcd37149b86"},
+    {file = "watchfiles-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04e4ed5d1cd3eae68c89bcc1a485a109f39f2fd8de05f705e98af6b5f1861f1f"},
+    {file = "watchfiles-1.1.0-cp39-cp39-win32.whl", hash = "sha256:c600e85f2ffd9f1035222b1a312aff85fd11ea39baff1d705b9b047aad2ce267"},
+    {file = "watchfiles-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:3aba215958d88182e8d2acba0fdaf687745180974946609119953c0e112397dc"},
+    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3a6fd40bbb50d24976eb275ccb55cd1951dfb63dbc27cae3066a6ca5f4beabd5"},
+    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9f811079d2f9795b5d48b55a37aa7773680a5659afe34b54cc1d86590a51507d"},
+    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2726d7bfd9f76158c84c10a409b77a320426540df8c35be172444394b17f7ea"},
+    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df32d59cb9780f66d165a9a7a26f19df2c7d24e3bd58713108b41d0ff4f929c6"},
+    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0ece16b563b17ab26eaa2d52230c9a7ae46cf01759621f4fbbca280e438267b3"},
+    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:51b81e55d40c4b4aa8658427a3ee7ea847c591ae9e8b81ef94a90b668999353c"},
+    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2bcdc54ea267fe72bfc7d83c041e4eb58d7d8dc6f578dfddb52f037ce62f432"},
+    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:923fec6e5461c42bd7e3fd5ec37492c6f3468be0499bc0707b4bbbc16ac21792"},
+    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7b3443f4ec3ba5aa00b0e9fa90cf31d98321cbff8b925a7c7b84161619870bc9"},
+    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7049e52167fc75fc3cc418fc13d39a8e520cbb60ca08b47f6cedb85e181d2f2a"},
+    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54062ef956807ba806559b3c3d52105ae1827a0d4ab47b621b31132b6b7e2866"},
+    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a7bd57a1bb02f9d5c398c0c1675384e7ab1dd39da0ca50b7f09af45fa435277"},
+    {file = "watchfiles-1.1.0.tar.gz", hash = "sha256:693ed7ec72cbfcee399e92c895362b6e66d63dac6b91e2c11ae03d10d503e575"},
+]
+
+[package.dependencies]
+anyio = ">=3.0.0"
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c"},
+    {file = "websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256"},
+    {file = "websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf"},
+    {file = "websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85"},
+    {file = "websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597"},
+    {file = "websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9"},
+    {file = "websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4"},
+    {file = "websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa"},
+    {file = "websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880"},
+    {file = "websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411"},
+    {file = "websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123"},
+    {file = "websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f"},
+    {file = "websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee"},
+]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "bb00cff5c4a199cb9322605149f72caeae06d2bdc0997c930bb777296a0633bb"
+content-hash = "3fa00141d22683f5ccd6c7baf82fa7e4beba2df7ad662b1f1a680dd6688ec6b2"

--- a/python_src/pyproject.toml
+++ b/python_src/pyproject.toml
@@ -5,7 +5,12 @@ description = ""
 requires-python = ">=3.12"
 dependencies = [
     "pydantic (>=2.11.7,<3.0.0)",
-    "pytz (>=2025.2,<2026.0)"
+    "pytz (>=2025.2,<2026.0)",
+    "pydantic-settings (>=2.10.1,<3.0.0)",
+    "httpx (>=0.28.1,<0.29.0)",
+    "uvicorn[standard] (>=0.35.0,<0.36.0)",
+    "structlog (>=25.4.0,<26.0.0)",
+    "fastapi (>=0.115.14,<0.116.0)"
 ]
 
 
@@ -64,7 +69,6 @@ reportUnusedExpression = true
 markers = [
     "unit",
 ]
-asyncio_mode = "auto"
 addopts = [
     "-vv",
     "--timer-top-n=10"

--- a/python_src/tests/__init__.py
+++ b/python_src/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/python_src/tests/domain/__init__.py
+++ b/python_src/tests/domain/__init__.py
@@ -1,0 +1,1 @@
+# Domain tests package

--- a/python_src/tests/domain/common/__init__.py
+++ b/python_src/tests/domain/common/__init__.py
@@ -1,0 +1,1 @@
+# Domain common tests package

--- a/python_src/tests/domain/common/test_error.py
+++ b/python_src/tests/domain/common/test_error.py
@@ -1,0 +1,262 @@
+"""Tests for domain error functionality."""
+
+from http import HTTPStatus
+
+import pytest
+
+from internal.domain.common.error import DomainError, new_error
+from internal.domain.common.error_code import NOT_FOUND, VALIDATION_ERROR, ErrorCode
+
+
+class TestDomainError:
+    """Test DomainError class."""
+
+    def test_create_domain_error_minimal(self):
+        """Test creating DomainError with minimal parameters."""
+        code = ErrorCode(name="TEST_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+        error = DomainError(code=code)
+
+        assert error.code == code
+        assert error.err is None
+        assert error._client_msg == ""
+        assert error.remote_status == 0
+        assert error.detail == {}
+
+    def test_create_domain_error_full(self):
+        """Test creating DomainError with all parameters."""
+        code = ErrorCode(name="FULL_ERROR", status_code=HTTPStatus.NOT_FOUND)
+        original_error = ValueError("Original error")
+        client_msg = "User-friendly message"
+        remote_status = 503
+        detail = {"field": "value", "count": 42}
+
+        error = DomainError(
+            code=code, err=original_error, client_msg=client_msg, remote_status=remote_status, detail=detail
+        )
+
+        assert error.code == code
+        assert error.err == original_error
+        assert error._client_msg == client_msg
+        assert error.remote_status == remote_status
+        assert error.detail == detail
+
+    def test_domain_error_message_building(self):
+        """Test DomainError message building logic."""
+        code = ErrorCode(name="MESSAGE_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        # Test with only client message
+        error1 = DomainError(code=code, client_msg="Client message")
+        assert str(error1) == "Client message"
+
+        # Test with remote status and client message
+        error2 = DomainError(code=code, client_msg="Client message", remote_status=404)
+        assert str(error2) == "404: Client message"
+
+        # Test with original error and client message
+        original_error = ValueError("Original error")
+        error3 = DomainError(code=code, err=original_error, client_msg="Client message")
+        assert str(error3) == "Original error: Client message"
+
+        # Test with all components
+        error4 = DomainError(code=code, err=original_error, client_msg="Client message", remote_status=503)
+        assert str(error4) == "503: Original error: Client message"
+
+    def test_domain_error_name_method(self):
+        """Test DomainError name() method."""
+        code = ErrorCode(name="NAMED_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+        error = DomainError(code=code)
+
+        assert error.name() == "NAMED_ERROR"
+
+        # Test with empty name
+        empty_code = ErrorCode(name="", status_code=HTTPStatus.BAD_REQUEST)
+        empty_error = DomainError(code=empty_code)
+        assert empty_error.name() == "UNKNOWN_ERROR"
+
+    def test_domain_error_client_msg_method(self):
+        """Test DomainError client_msg() method."""
+        code = ErrorCode(name="CLIENT_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        # Test with client message
+        error1 = DomainError(code=code, client_msg="User message")
+        assert error1.client_msg() == "User message"
+
+        # Test without client message
+        error2 = DomainError(code=code)
+        assert error2.client_msg() == ""
+
+    def test_domain_error_http_status_method(self):
+        """Test DomainError http_status() method."""
+        code = ErrorCode(name="HTTP_ERROR", status_code=HTTPStatus.NOT_FOUND)
+        error = DomainError(code=code)
+
+        assert error.http_status() == 404
+
+        # Test with zero status code
+        zero_code = ErrorCode(name="ZERO_ERROR", status_code=0)
+        zero_error = DomainError(code=zero_code)
+        assert zero_error.http_status() == 500
+
+    def test_domain_error_remote_http_status_method(self):
+        """Test DomainError remote_http_status() method."""
+        code = ErrorCode(name="REMOTE_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        # Test with remote status
+        error1 = DomainError(code=code, remote_status=503)
+        assert error1.remote_http_status() == 503
+
+        # Test without remote status
+        error2 = DomainError(code=code)
+        assert error2.remote_http_status() == 0
+
+    def test_domain_error_get_detail_method(self):
+        """Test DomainError get_detail() method."""
+        code = ErrorCode(name="DETAIL_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        # Test with detail
+        detail = {"key": "value", "number": 123}
+        error1 = DomainError(code=code, detail=detail)
+        assert error1.get_detail() == detail
+
+        # Test without detail (should default to empty dict)
+        error2 = DomainError(code=code)
+        assert error2.get_detail() == {}
+
+        # Test with None detail (should convert to empty dict)
+        error3 = DomainError(code=code, detail=None)
+        assert error3.get_detail() == {}
+
+    def test_domain_error_inheritance(self):
+        """Test that DomainError properly inherits from Exception."""
+        code = ErrorCode(name="INHERITANCE_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+        error = DomainError(code=code, client_msg="Test message")
+
+        assert isinstance(error, Exception)
+        assert isinstance(error, DomainError)
+
+        # Test raising and catching
+        with pytest.raises(DomainError) as exc_info:
+            raise error
+
+        caught_error = exc_info.value
+        assert caught_error.code == code
+        assert caught_error.client_msg() == "Test message"
+
+    def test_domain_error_with_predefined_codes(self):
+        """Test DomainError with predefined error codes."""
+        # Test with VALIDATION_ERROR
+        validation_error = DomainError(code=VALIDATION_ERROR, client_msg="Invalid input")
+        assert validation_error.name() == "VALIDATION_ERROR"
+        assert validation_error.http_status() == 400
+
+        # Test with NOT_FOUND
+        not_found_error = DomainError(code=NOT_FOUND, client_msg="Resource not found")
+        assert not_found_error.name() == "NOT_FOUND"
+        assert not_found_error.http_status() == 404
+
+
+class TestNewErrorFunction:
+    """Test new_error() convenience function."""
+
+    def test_new_error_minimal(self):
+        """Test new_error with minimal parameters."""
+        code = ErrorCode(name="NEW_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+        error = new_error(code=code)
+
+        assert isinstance(error, DomainError)
+        assert error.code == code
+        assert error.err is None
+        assert error._client_msg == ""
+        assert error.remote_status == 0
+        assert error.detail == {}
+
+    def test_new_error_full(self):
+        """Test new_error with all parameters."""
+        code = ErrorCode(name="NEW_FULL_ERROR", status_code=HTTPStatus.FORBIDDEN)
+        original_error = RuntimeError("Runtime issue")
+        client_msg = "Access denied"
+        remote_status = 403
+        detail = {"user_id": "123", "resource": "secret"}
+
+        error = new_error(
+            code=code, err=original_error, client_msg=client_msg, remote_status=remote_status, detail=detail
+        )
+
+        assert isinstance(error, DomainError)
+        assert error.code == code
+        assert error.err == original_error
+        assert error._client_msg == client_msg
+        assert error.remote_status == remote_status
+        assert error.detail == detail
+
+    def test_new_error_with_predefined_codes(self):
+        """Test new_error with predefined error codes."""
+        # Test with VALIDATION_ERROR
+        validation_error = new_error(
+            code=VALIDATION_ERROR, client_msg="Invalid email format", detail={"field": "email"}
+        )
+
+        assert validation_error.name() == "VALIDATION_ERROR"
+        assert validation_error.http_status() == 400
+        assert validation_error.client_msg() == "Invalid email format"
+        assert validation_error.get_detail() == {"field": "email"}
+
+    def test_new_error_convenience(self):
+        """Test that new_error is more convenient than direct DomainError construction."""
+        code = ErrorCode(name="CONVENIENCE_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        # Using new_error
+        error1 = new_error(code, client_msg="Easy to use")
+
+        # Using DomainError directly
+        error2 = DomainError(code=code, client_msg="Easy to use")
+
+        # Both should be equivalent
+        assert error1.code == error2.code
+        assert error1.client_msg() == error2.client_msg()
+        assert error1.name() == error2.name()
+        assert error1.http_status() == error2.http_status()
+
+
+class TestErrorIntegration:
+    """Integration tests for error components."""
+
+    def test_error_workflow(self):
+        """Test a complete error handling workflow."""
+        # Create a custom error code
+        custom_code = ErrorCode(name="WORKFLOW_ERROR", status_code=HTTPStatus.UNPROCESSABLE_ENTITY)
+
+        # Create an error with context
+        original_exception = ValueError("Database connection failed")
+        error = new_error(
+            code=custom_code,
+            err=original_exception,
+            client_msg="Unable to process request",
+            remote_status=503,
+            detail={"service": "database", "retry_after": 30},
+        )
+
+        # Verify all properties
+        assert error.name() == "WORKFLOW_ERROR"
+        assert error.http_status() == 422
+        assert error.remote_http_status() == 503
+        assert error.client_msg() == "Unable to process request"
+        assert error.get_detail()["service"] == "database"
+        assert "Database connection failed" in str(error)
+
+    def test_error_chaining(self):
+        """Test error chaining scenarios."""
+        # Simulate nested error handling
+        try:
+            # Simulate a low-level error
+            raise ConnectionError("Network timeout")
+        except ConnectionError as e:
+            # Wrap in domain error
+            domain_error = new_error(
+                code=NOT_FOUND, err=e, client_msg="Service temporarily unavailable", remote_status=503
+            )
+
+            # Verify the chain
+            assert isinstance(domain_error.err, ConnectionError)
+            assert "Network timeout" in str(domain_error)
+            assert domain_error.client_msg() == "Service temporarily unavailable"

--- a/python_src/tests/domain/common/test_error_code.py
+++ b/python_src/tests/domain/common/test_error_code.py
@@ -1,0 +1,143 @@
+"""Tests for error code functionality."""
+
+from http import HTTPStatus
+
+import pytest
+from pydantic import ValidationError
+
+from internal.domain.common.error_code import (
+    FORBIDDEN,
+    INTERNAL_ERROR,
+    NOT_FOUND,
+    UNAUTHORIZED,
+    UNKNOWN_ERROR,
+    VALIDATION_ERROR,
+    ErrorCode,
+)
+
+
+class TestErrorCode:
+    """Test ErrorCode pydantic model."""
+
+    def test_create_error_code_with_explicit_status(self):
+        """Test creating ErrorCode with explicit status code."""
+        error = ErrorCode(name="TEST_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        assert error.name == "TEST_ERROR"
+        assert error.status_code == HTTPStatus.BAD_REQUEST
+        assert error.status_code == 400
+
+    def test_create_error_code_with_default_status(self):
+        """Test creating ErrorCode with default status code."""
+        error = ErrorCode(name="DEFAULT_ERROR")
+
+        assert error.name == "DEFAULT_ERROR"
+        assert error.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert error.status_code == 500
+
+    def test_error_code_immutability(self):
+        """Test that ErrorCode is immutable (frozen)."""
+        error = ErrorCode(name="IMMUTABLE_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        with pytest.raises(ValidationError):
+            error.name = "CHANGED_NAME"
+
+        with pytest.raises(ValidationError):
+            error.status_code = HTTPStatus.NOT_FOUND
+
+    def test_error_code_equality(self):
+        """Test ErrorCode equality comparison."""
+        error1 = ErrorCode(name="TEST_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+        error2 = ErrorCode(name="TEST_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+        error3 = ErrorCode(name="DIFFERENT_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        assert error1 == error2
+        assert error1 != error3
+
+    def test_error_code_string_representation(self):
+        """Test ErrorCode string representation."""
+        error = ErrorCode(name="TEST_ERROR", status_code=HTTPStatus.BAD_REQUEST)
+
+        str_repr = str(error)
+        assert "TEST_ERROR" in str_repr
+        assert "400" in str_repr
+
+    def test_error_code_validation(self):
+        """Test ErrorCode validation."""
+        # Valid name
+        ErrorCode(name="VALID_NAME", status_code=HTTPStatus.OK)
+
+        # Empty name should work
+        ErrorCode(name="", status_code=HTTPStatus.OK)
+
+        # Invalid status code type should raise ValidationError
+        with pytest.raises(ValidationError):
+            ErrorCode(name="TEST_ERROR", status_code="invalid")  # type: ignore[arg-type]
+
+    def test_error_code_serialization(self):
+        """Test ErrorCode serialization to dict."""
+        error = ErrorCode(name="SERIALIZE_ERROR", status_code=HTTPStatus.NOT_FOUND)
+
+        data = error.model_dump()
+        assert data == {"name": "SERIALIZE_ERROR", "status_code": 404}
+
+    def test_error_code_deserialization(self):
+        """Test ErrorCode deserialization from dict."""
+        data = {"name": "DESERIALIZE_ERROR", "status_code": 403}
+
+        error = ErrorCode.model_validate(data)
+        assert error.name == "DESERIALIZE_ERROR"
+        assert error.status_code == HTTPStatus.FORBIDDEN
+
+
+class TestPredefinedErrorCodes:
+    """Test predefined error code constants."""
+
+    def test_unknown_error(self):
+        """Test UNKNOWN_ERROR constant."""
+        assert UNKNOWN_ERROR.name == "UNKNOWN_ERROR"
+        assert UNKNOWN_ERROR.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def test_validation_error(self):
+        """Test VALIDATION_ERROR constant."""
+        assert VALIDATION_ERROR.name == "VALIDATION_ERROR"
+        assert VALIDATION_ERROR.status_code == HTTPStatus.BAD_REQUEST
+
+    def test_not_found_error(self):
+        """Test NOT_FOUND constant."""
+        assert NOT_FOUND.name == "NOT_FOUND"
+        assert NOT_FOUND.status_code == HTTPStatus.NOT_FOUND
+
+    def test_unauthorized_error(self):
+        """Test UNAUTHORIZED constant."""
+        assert UNAUTHORIZED.name == "UNAUTHORIZED"
+        assert UNAUTHORIZED.status_code == HTTPStatus.UNAUTHORIZED
+
+    def test_forbidden_error(self):
+        """Test FORBIDDEN constant."""
+        assert FORBIDDEN.name == "FORBIDDEN"
+        assert FORBIDDEN.status_code == HTTPStatus.FORBIDDEN
+
+    def test_internal_error(self):
+        """Test INTERNAL_ERROR constant."""
+        assert INTERNAL_ERROR.name == "INTERNAL_ERROR"
+        assert INTERNAL_ERROR.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def test_predefined_errors_are_immutable(self):
+        """Test that predefined error codes are immutable."""
+        with pytest.raises(ValidationError):
+            VALIDATION_ERROR.name = "CHANGED_NAME"
+
+        with pytest.raises(ValidationError):
+            NOT_FOUND.status_code = HTTPStatus.OK
+
+    def test_all_predefined_errors_exist(self):
+        """Test that all expected predefined errors exist and have correct types."""
+        predefined_errors = [UNKNOWN_ERROR, VALIDATION_ERROR, NOT_FOUND, UNAUTHORIZED, FORBIDDEN, INTERNAL_ERROR]
+
+        for error in predefined_errors:
+            assert isinstance(error, ErrorCode)
+            assert isinstance(error.name, str)
+            assert isinstance(error.status_code, int)
+            assert error.name  # Not empty
+            assert 100 <= error.status_code <= 599  # Valid HTTP status code range

--- a/python_src/tests/domain/common/test_requestid.py
+++ b/python_src/tests/domain/common/test_requestid.py
@@ -1,0 +1,304 @@
+"""Tests for request ID management functionality."""
+
+import asyncio
+import uuid
+
+from internal.domain.common.requestid import (
+    _request_id_var,
+    get_request_id,
+    get_request_id_or_new,
+    new_request_id,
+    set_request_id,
+)
+
+
+class TestRequestIdFunctions:
+    """Test request ID management functions."""
+
+    def test_new_request_id_format(self):
+        """Test that new_request_id generates valid UUIDs."""
+        request_id = new_request_id()
+
+        # Should be a string
+        assert isinstance(request_id, str)
+
+        # Should be a valid UUID format
+        uuid_obj = uuid.UUID(request_id)
+        assert str(uuid_obj) == request_id
+
+        # Should be version 4 UUID
+        assert uuid_obj.version == 4
+
+    def test_new_request_id_uniqueness(self):
+        """Test that new_request_id generates unique IDs."""
+        ids = [new_request_id() for _ in range(100)]
+
+        # All should be unique
+        assert len(set(ids)) == 100
+
+    def test_set_and_get_request_id(self):
+        """Test setting and getting request ID."""
+        test_id = "test-request-id-123"
+
+        # Set the request ID
+        set_request_id(test_id)
+
+        # Get the request ID
+        retrieved_id = get_request_id()
+
+        assert retrieved_id == test_id
+
+    def test_get_request_id_empty_default(self):
+        """Test that get_request_id returns empty string when not set."""
+        # Clear any existing request ID
+        _request_id_var.set("")
+
+        # Should return empty string
+        assert get_request_id() == ""
+
+    def test_get_request_id_or_new_with_existing(self):
+        """Test get_request_id_or_new when request ID already exists."""
+        existing_id = "existing-request-id"
+        set_request_id(existing_id)
+
+        # Should return the existing ID
+        result = get_request_id_or_new()
+        assert result == existing_id
+
+    def test_get_request_id_or_new_without_existing(self):
+        """Test get_request_id_or_new when no request ID exists."""
+        # Clear any existing request ID
+        _request_id_var.set("")
+
+        # Should generate and set a new ID
+        result = get_request_id_or_new()
+
+        # Should be a valid UUID
+        uuid.UUID(result)  # Will raise if not valid
+
+        # Should be set in context
+        assert get_request_id() == result
+
+    def test_request_id_context_isolation(self):
+        """Test that request IDs are isolated per context."""
+        results = []
+
+        async def set_and_get_id(test_id: str):
+            set_request_id(test_id)
+            # Yield control to allow other tasks to run
+            await asyncio.sleep(0.001)
+            results.append(get_request_id())
+
+        async def test_isolation():
+            # Run multiple tasks concurrently
+            await asyncio.gather(set_and_get_id("id-1"), set_and_get_id("id-2"), set_and_get_id("id-3"))
+
+        # Run the test
+        asyncio.run(test_isolation())
+
+        # Each task should have maintained its own request ID
+        assert len(results) == 3
+        assert "id-1" in results
+        assert "id-2" in results
+        assert "id-3" in results
+
+    def test_request_id_inheritance_in_tasks(self):
+        """Test that request IDs are inherited by child tasks."""
+        parent_id = "parent-request-id"
+        child_results = []
+
+        async def child_task():
+            # Child should inherit parent's request ID
+            child_results.append(get_request_id())
+
+        async def parent_task():
+            # Set request ID in parent
+            set_request_id(parent_id)
+
+            # Create child task
+            await asyncio.create_task(child_task())
+
+        # Run the test
+        asyncio.run(parent_task())
+
+        # Child should have inherited parent's request ID
+        assert len(child_results) == 1
+        assert child_results[0] == parent_id
+
+    def test_request_id_modification_in_child_task(self):
+        """Test that child task modifications don't affect parent context."""
+        parent_id = "parent-id"
+        child_id = "child-id"
+        final_parent_id = None
+
+        async def child_task():
+            # Child modifies request ID
+            set_request_id(child_id)
+            return get_request_id()
+
+        async def parent_task():
+            nonlocal final_parent_id
+
+            # Set request ID in parent
+            set_request_id(parent_id)
+
+            # Create child task that modifies request ID
+            child_result = await asyncio.create_task(child_task())
+
+            # Check that child modification doesn't affect parent
+            final_parent_id = get_request_id()
+
+            return child_result
+
+        # Run the test
+        child_result = asyncio.run(parent_task())
+
+        # Child should have its own modified ID
+        assert child_result == child_id
+
+        # Parent should retain its original ID
+        assert final_parent_id == parent_id
+
+    def test_context_var_direct_access(self):
+        """Test direct access to the context variable."""
+        # This tests the internal implementation
+        test_id = "direct-access-test"
+
+        # Set via direct context var access
+        _request_id_var.set(test_id)
+
+        # Should be retrievable via our function
+        assert get_request_id() == test_id
+
+        # Should also be retrievable via direct access
+        assert _request_id_var.get() == test_id
+
+    def test_empty_string_handling(self):
+        """Test handling of empty strings."""
+        # Set empty string
+        set_request_id("")
+
+        # get_request_id should return empty string
+        assert get_request_id() == ""
+
+        # get_request_id_or_new should generate new ID
+        new_id = get_request_id_or_new()
+        assert new_id != ""
+        uuid.UUID(new_id)  # Should be valid UUID
+
+        # Should now return the generated ID
+        assert get_request_id() == new_id
+
+    def test_whitespace_handling(self):
+        """Test handling of whitespace-only strings."""
+        whitespace_id = "   "
+        set_request_id(whitespace_id)
+
+        # Should preserve whitespace
+        assert get_request_id() == whitespace_id
+
+        # get_request_id_or_new should treat it as existing
+        result = get_request_id_or_new()
+        assert result == whitespace_id
+
+
+class TestRequestIdIntegration:
+    """Integration tests for request ID functionality."""
+
+    def test_typical_request_flow(self):
+        """Test a typical request processing flow."""
+        # Simulate incoming request without request ID
+        _request_id_var.set("")
+
+        # Middleware generates request ID
+        request_id = get_request_id_or_new()
+        assert request_id != ""
+
+        # Request processing uses the same ID
+        processing_id = get_request_id()
+        assert processing_id == request_id
+
+        # Logging uses the same ID
+        logging_id = get_request_id()
+        assert logging_id == request_id
+
+    def test_request_with_existing_id(self):
+        """Test processing request that already has an ID."""
+        incoming_id = "incoming-request-id"
+
+        # Simulate incoming request with existing ID
+        set_request_id(incoming_id)
+
+        # Middleware should use existing ID
+        middleware_id = get_request_id_or_new()
+        assert middleware_id == incoming_id
+
+        # All subsequent operations use the same ID
+        assert get_request_id() == incoming_id
+
+    def test_concurrent_requests(self):
+        """Test handling multiple concurrent requests."""
+        results = []
+
+        async def process_request(request_num: int):
+            # Clear any existing request ID to simulate new request
+            _request_id_var.set("")
+
+            # Each request gets its own ID
+            request_id = get_request_id_or_new()
+
+            # Simulate some async work
+            await asyncio.sleep(0.001)
+
+            # Verify ID is still correct
+            final_id = get_request_id()
+            results.append((request_num, request_id, final_id))
+
+        async def test_concurrent():
+            # Process multiple requests concurrently
+            await asyncio.gather(*[process_request(i) for i in range(10)])
+
+        # Run the test
+        asyncio.run(test_concurrent())
+
+        # Verify results
+        assert len(results) == 10
+
+        # Each request should have consistent ID throughout
+        for _, initial_id, final_id in results:
+            assert initial_id == final_id
+            # Should be valid UUID
+            uuid.UUID(initial_id)
+
+        # All request IDs should be unique
+        all_ids = [initial_id for _, initial_id, _ in results]
+        assert len(set(all_ids)) == 10
+
+    def test_nested_operation_context(self):
+        """Test request ID in nested operations."""
+        main_request_id = "main-request"
+        nested_results = []
+
+        async def nested_operation(level: int):
+            # Should inherit request ID from parent context
+            current_id = get_request_id()
+            nested_results.append((level, current_id))
+
+            if level > 0:
+                # Create deeper nesting
+                await asyncio.create_task(nested_operation(level - 1))
+
+        async def main_operation():
+            # Set main request ID
+            set_request_id(main_request_id)
+
+            # Perform nested operations
+            await nested_operation(3)
+
+        # Run the test
+        asyncio.run(main_operation())
+
+        # All nested operations should have the same request ID
+        assert len(nested_results) == 4  # Levels 3, 2, 1, 0
+        for _, request_id in nested_results:
+            assert request_id == main_request_id


### PR DESCRIPTION
## 🤔 Why

The project was originally implemented in Golang using the clean architecture pattern. However, to better align with our team's expertise and ecosystem, we decided to migrate the codebase to Python. This transformation enables easier onboarding, faster iteration, and better integration with our existing Python-based tooling and infrastructure.

## 💡 How

- Re-implemented the core structure of the application in Python, adopting the same clean architecture principles (separation of domain, router, middleware, and application layers).
- Introduced FastAPI for the HTTP server to provide a modern, high-performance, and type-safe web framework.
- Added Pythonic equivalents for configuration management (`pydantic-settings`), structured logging (`structlog`), and request ID handling (using contextvars).
- Created a new CI workflow for Python, including linting (isort, black, pyright) and testing (pytest).
- Added a Makefile for common development tasks (init, test, lint, run, run-prod).
- Provided example environment variable configuration (`env.example`).
- Established a basic API structure with health check endpoint and middleware for logging and request IDs.
- Updated `poetry.lock` with all necessary dependencies.

**Stuff to watch out for:**
- Python 3.12 is required (see CI and `pyproject.toml`).
- New dependencies are introduced; run `make init` or use `poetry install` in `python_src`.
- The application entrypoint is now `python_src/cmd/app/http_server.py` (via uvicorn).
- API endpoints and architecture are structured for extensibility, matching the previous Golang clean-arch layout.

**Asana Link:** <!-- Asana Link -->

## Check list
- Asana Link: <!-- Asana Link-->
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?

---