### PR TITLE
chore(pyright): exclude tests from checks

### DIFF
--- a/python_src/pyproject.toml
+++ b/python_src/pyproject.toml
@@ -49,6 +49,7 @@ atomic = true
 
 [tool.pyright]
 #include = ["python_src"]
+exclude = ["tests"]
 strictListInference = true
 strictSetInference = true
 # since the dictionary may contain various values, we disable the strict dictionary inference


### PR DESCRIPTION
## 🤔 Why

Pyright was running static analysis on the test suite, resulting in unnecessary noise and false positives that are not relevant to our application code. This made it harder to focus on meaningful type issues in the core codebase and slowed down our development workflow.

## 💡 How

- Updated `pyproject.toml` to add the `exclude = ["tests"]` directive for Pyright.
- This change ensures that only the application code is checked by Pyright, making the type checking process faster and the results more actionable.
- No API changes or new dependencies introduced.
- No impact on production code or test execution—this only affects static type checking.

## Check list
- Asana Link:
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?