### PR TITLE
build: simplify pyenv-virtualenv install and check poetry version

### DIFF
--- a/python_src/Makefile
+++ b/python_src/Makefile
@@ -65,16 +65,7 @@ check-install-pyenv-virtualenv:
 	@echo "🔍 Checking pyenv-virtualenv installation..."
 	@if ! pyenv commands | grep -q virtualenv; then \
 		echo "📦 Installing pyenv-virtualenv..."; \
-		if [[ "$(shell uname)" == "Darwin" ]]; then \
-			if command -v brew &> /dev/null; then \
-				brew install pyenv-virtualenv; \
-			else \
-				echo "❌ Homebrew not found. Please install Homebrew first."; \
-				exit 1; \
-			fi; \
-		else \
-			git clone https://github.com/pyenv/pyenv-virtualenv.git $$(pyenv root)/plugins/pyenv-virtualenv; \
-		fi; \
+		git clone https://github.com/pyenv/pyenv-virtualenv.git $$(pyenv root)/plugins/pyenv-virtualenv; \
 		$(MAKE) setup-pyenv-virtualenv-shell; \
 	else \
 		echo "✅ pyenv-virtualenv is already installed"; \
@@ -109,7 +100,17 @@ check-install-poetry:
 		curl -sSL https://install.python-poetry.org | python3 -; \
 		$(MAKE) setup-poetry-shell; \
 	else \
-		echo "✅ poetry is already installed"; \
+		echo "✅ poetry is installed, checking version..."; \
+		POETRY_VERSION=$$(poetry --version 2>/dev/null | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1); \
+		MAJOR_VERSION=$$(echo $$POETRY_VERSION | cut -d. -f1); \
+		if [ "$$MAJOR_VERSION" != "2" ]; then \
+			echo "⚠️  Poetry version $$POETRY_VERSION detected (major version: $$MAJOR_VERSION)"; \
+			echo "📦 Reinstalling poetry to latest version (major version 2)..."; \
+			curl -sSL https://install.python-poetry.org | python3 -; \
+			$(MAKE) setup-poetry-shell; \
+		else \
+			echo "✅ poetry version $$POETRY_VERSION is compatible (major version 2)"; \
+		fi; \
 	fi
 
 # Install dependencies


### PR DESCRIPTION
## 🤔 Why

The previous installation logic for `pyenv-virtualenv` was unnecessarily complex and platform-dependent, requiring different steps for macOS and other systems. This added maintenance overhead and potential failure points. Additionally, there was no check to ensure that the installed version of Poetry matched the required major version (v2), which could lead to compatibility issues if an outdated version was present.

## 💡 How

- Simplified the installation of `pyenv-virtualenv` by always cloning from GitHub, removing the special handling for macOS/Homebrew. This makes the process more consistent and easier to maintain.
- Enhanced the Poetry installation step to check the installed Poetry version. If the major version is not 2, Poetry is automatically reinstalled to the latest v2 release, ensuring compatibility with our tooling.
- No API changes or new dependencies are introduced, but developers may see Poetry being reinstalled if an incompatible version is detected.

## Check list
- Asana Link: <!-- Asana Link-->
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?

---