### PR TITLE
chore: Update video sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,14 @@ At Crescendo Lab:
 # Case Study - Extend Line Auto-Reply to Omnichannel Auto-Reply
 
 Auto-Reply (Keyword + General):
-<video width="640" height="480" controls>
-  <source src="https://drive.google.com/uc?export=download&id=150uIbDx_ZageXc-ofMVt62PUgs_gFq36" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
+
+https://github.com/user-attachments/assets/f1a52e80-2664-4694-b675-4534b5f1f4bc
 
 Auto-Reply (IG Story-Specific):
-<video width="640" height="480" controls>
-  <source src="https://drive.google.com/uc?export=download&id=10L-x17h9JHhErp4OtBG0Kc7y8s7QpGny" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
+
+https://github.com/user-attachments/assets/7d6c07c0-cb5f-4645-b150-e2b25925c858
+
+
 
 - Auto-Reply Intro: [CH](https://crescendolab.zendesk.com/hc/zh-tw/articles/48047855114137-%E5%8A%9F%E8%83%BD%E8%AA%AA%E6%98%8E-Omnichannel-%E8%87%AA%E5%8B%95%E5%9B%9E%E6%87%89-%E5%90%AB-FB-IG-LINE), EN
 - Auto-Reply Tutorials: [CH](https://crescendolab.zendesk.com/hc/zh-tw/articles/48502467789209-%E8%A8%AD%E5%AE%9A%E6%95%99%E5%AD%B8-Omnichannel-%E8%87%AA%E5%8B%95%E5%9B%9E%E6%87%89), [EN](https://crescendolab.zendesk.com/hc/en-us/articles/39949866982425-Tutorials-NEW-Auto-reply)


### PR DESCRIPTION
## 🤔 Why

The previous video sources embedded in the README were hosted on Google Drive and required the use of an HTML `<video>` tag, which can lead to inconsistent playback across platforms and may not be supported or rendered properly on GitHub. This caused issues for users trying to view the demo videos directly from the README, reducing accessibility and clarity.

## 💡 How

- Updated the video sources in the README to use direct GitHub asset links. The new links point to video files hosted as GitHub user-attachments, which are reliably accessible and render as clickable links or previews directly within GitHub.
- Removed the `<video>` HTML tags to simplify the markdown and ensure compatibility with GitHub's markdown renderer.
- No API changes or new dependencies are introduced.
- No feature flag is required.
- No new tests are necessary as this is a documentation update.

## Check list
- Asana Link: <!-- Asana Link-->
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?

---