### PR TITLE
docs: enhance README with AI coding principles and workshop outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,112 @@
 
 This is an internal workshop held at Crescendo Lab that demonstrates how to improve product velocity and quality by leveraging AI agentic coding practices.
 
-## AI Coding Practices at CL
+By the end of this workshop, participants will master:
 
-At Crescendo Lab:
-- We **don't practice vibe coding**. 
-- We **provide AI with as much context as possible** to guide them in developing and validating product features efficiently.
-- We believe **AI coding capability is driven and scoped by humans** who are skilled in domain and software knowledge, make technical decisions, and have the capability to evaluate AI's coding outputs.
-- We learn when to leverage agentic coding and when to code hands-on (with auto-complete) by ourselves.
+- **Context-Driven Development** - Provide comprehensive context (PRD, KB, domain models) to AI for better code generation
+- **Structured AI Collaboration** - Move from "vibe coding" to systematic, intentional AI interactions
+- **Design-First Approach** - Plan interfaces and tasks before implementation
+- **Quality Assurance** - Validate and test AI-generated code systematically
+- **When to Use AI** - Identify tasks that benefit from agentic coding vs. hands-on development
+- **Knowledge Base Management** - Extract and maintain domain expertise for better AI context
 
-# Case Study - Extend Line Auto-Reply to Omnichannel Auto-Reply
+## AI Coding Principles at CL
 
-Auto-Reply (Keyword + General):
+At Crescendo Lab, we follow the **3 C's** of AI coding:
+
+- **Context**: Provide comprehensive background before coding (PRD, KB, domain models)
+- **Control**: Humans drive decisions, AI executes (we scope and evaluate AI outputs)
+- **Critique**: Always validate and verify outputs (no vibe coding, systematic testing)
+
+## Workshop Outline
+
+This workshop guides participants through step-by-step agentic coding practice using the [Omnichannel Auto-Reply](#case-study---omnichannel-auto-reply) case study across the following sections:
+
+| Section | Topic                  | Description                                                                 | Estimated Time |
+|---------|------------------------|-----------------------------------------------------------------------------|----------------|
+| 1       | Rewrite Brownfield     | Build Omnichannel Auto-Reply trigger logic with agentic coding              | 1h 20m         |
+| 2       | Extend Functions       | Extend Omnichannel Auto-Reply to support IG story-specific                  | 40m            |
+| 3       | KB Extraction          | Extract knowledge from codebase and tribal knowledge for critical features  | 40m            |
+| 4       | Sharpen your prompts   | Patterns for effective agent instructions                                   | 20m            |
+
+## Codebase Outline
+
+This workshop provides both Go and Python implementations and reference materials:
+
+**Working Directories**
+- [go_src/](./go_src/) - Go implementation workspace for hands-on practice
+- [python_src/](./python_src/) - Python implementation workspace for hands-on practice
+
+**Reference Materials**
+- [cheat_sheet/](./cheat_sheet/) - Sample implementations and solutions
+  - `go/1_rewrite_brownfield/` - Go solution for Section 1
+  - `go/2_extend_feature/` - Go solution for Section 2
+  - `python/1_rewrite_brownfield/` - Python solution for Section 1
+  - `python/2_extend_feature/` - Python solution for Section 2
+- [legacy/](./legacy/) - Original LINE-only implementation for reference
+  - `kb/` - Knowledge base documents
+  - `line/` - Legacy Python LINE implementation
+  - `organization/` - Legacy organization models
+- [spec/](./spec/) - Product requirements and specifications
+  - `prd-part1.md` - Keyword + General Auto-Reply requirements
+  - `prd-part2.md` - IG Story-specific Auto-Reply requirements
+  - `ig_story.json` - IG Story webhook event sample
+
+---
+
+# Case Study - Omnichannel Auto-Reply
+
+## Background
+
+**Auto-Reply** is a critical product feature at CL that helps our customers automatically respond to their end users' messages using pre-defined keywords and time schedules via their [LINE official account](https://www.linebiz.com/jp-en/) (LINE OA).
+
+Currently, CL is planning to extend Auto-Reply to Facebook Messenger and Instagram accounts, based on the existing LINE version, called **Omnichannel Auto-Reply**.
+
+The key differences between the new and existing Auto-Reply:
+
+| Feature                      | Legacy System                                 | Omnichannel System                                         |
+|------------------------------|-----------------------------------------------|------------------------------------------------------------|
+| Platform Support             | LINE only                                     | LINE, Facebook Messenger, Instagram DMs                    |
+| Architecture                 | Single-channel, direct access                 | Multi-channel with parent-child model                      |
+| Data Model                   | WebhookTriggerSetting → WebhookTriggerMessage | AutoReply → AutoReplyChannelSetting → AutoReplyMessage     |
+| Keyword Triggers             | ✅ MESSAGE                                    | ✅ MESSAGE                                                 |
+| Keyword Match                | Case-sensitive exact match                    | Case-insensitive + trim spaces exact match                 |
+| Multiple Keywords per Rule   | ❌ One trigger_code per WebhookTriggerSetting | ✅ Multiple keywords per AutoReply rule                    |
+| General Time-based Triggers  | ✅ Schedule type priority                     | ✅ Schedule type priority                                  |
+| Cross-Platform Rules         | ❌ LINE only                                  | ✅ One rule → multiple channels                            |
+| IG Story Integration         | ❌ Not supported                              | ✅ 6-level priority system with story-specific triggers    |
+| Conflict Resolution          | First match wins, manual admin avoidance      | ✅ Automatic constraint validation                         |
+| Cross-Channel Reporting      | ❌ LINE only                                  | ✅ Channel-specific breakdowns                             |
+| Rule Management              | Per-bot configuration                         | ✅ Hierarchical parent-child model                         |
+| Backward Compatibility       | N/A                                           | ✅ Full LINE compatibility maintained                      |
+
+### Product Briefing
+
+**Videos**
+Omnichannel Auto-Reply (Keyword + General):
 
 https://github.com/user-attachments/assets/f1a52e80-2664-4694-b675-4534b5f1f4bc
 
-Auto-Reply (IG Story-Specific):
+Omnichannel Auto-Reply (IG Story-Specific):
 
 https://github.com/user-attachments/assets/7d6c07c0-cb5f-4645-b150-e2b25925c858
 
-
-
-- Auto-Reply Intro: [CH](https://crescendolab.zendesk.com/hc/zh-tw/articles/48047855114137-%E5%8A%9F%E8%83%BD%E8%AA%AA%E6%98%8E-Omnichannel-%E8%87%AA%E5%8B%95%E5%9B%9E%E6%87%89-%E5%90%AB-FB-IG-LINE), EN
+**Help Center Documentation**
+- Auto-Reply Introduction: [CH](https://crescendolab.zendesk.com/hc/zh-tw/articles/48047855114137-%E5%8A%9F%E8%83%BD%E8%AA%AA%E6%98%8E-Omnichannel-%E8%87%AA%E5%8B%95%E5%9B%9E%E6%87%89-%E5%90%AB-FB-IG-LINE), EN
 - Auto-Reply Tutorials: [CH](https://crescendolab.zendesk.com/hc/zh-tw/articles/48502467789209-%E8%A8%AD%E5%AE%9A%E6%95%99%E5%AD%B8-Omnichannel-%E8%87%AA%E5%8B%95%E5%9B%9E%E6%87%89), [EN](https://crescendolab.zendesk.com/hc/en-us/articles/39949866982425-Tutorials-NEW-Auto-reply)
 
 
-## Review given PRD, KB, and domain models
+### PRD, KB, and Domain Knowledge 
 
-- PRD: [here](./spec/prd.md)
-- KB: [here](./legacy/kb/auto_reply.md)
+PRDs
+- [Keyword + General](./spec/prd-part1.md)
+- [IG story-specific](./spec/prd-part2.md)
+
+KB & Domain models
+- [KB](./legacy/kb/auto_reply.md)
 - Domain models
-    - go: [here](./go_src/internal/domain/auto_reply/)
-    - python: here 
+    - [go](./go_src/internal/domain/)
+    - [python](./python_src/internal/domain/)
 
 ## 1. Rewrite Brownfield Features with AI
 


### PR DESCRIPTION
## 🤔 Why

The current README lacked clear documentation on Crescendo Lab’s AI coding principles and did not provide a structured outline for the internal workshop. This made it harder for participants and new contributors to understand the core philosophies behind our agentic coding practices and to follow the workshop in a systematic, effective way.

## 💡 How

- Expanded the README with a dedicated section on Crescendo Lab's AI coding principles, focusing on context, control, and critique.
- Added a comprehensive workshop outline that details learning objectives, step-by-step sections, and estimated timing.
- Introduced a codebase outline, specifying where to find Go and Python implementations, as well as reference solutions and legacy materials.
- Enhanced product and case study background for Omnichannel Auto-Reply, including feature comparison tables, video walkthroughs, and links to relevant documentation.
- No API/interface changes or new dependencies are required; this is a documentation update to improve onboarding and workshop experience.
- No feature flag or new tests are required as this is a docs-only change.

## Check list
- Asana Link: <!-- Asana Link-->
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?

---