### PR TITLE
chore: update GitHub Action for PR description generation

### DIFF
--- a/.github/workflows/bot_update_pr_description.yaml
+++ b/.github/workflows/bot_update_pr_description.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Generate PR Description
-        uses: platisd/openai-pr-description@master
+        uses: chatbotgang/openai-pr-description@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## 🤔 Why

The original GitHub Action (platisd/openai-pr-description) used for generating pull request descriptions is outdated and no longer maintained, which can lead to compatibility, reliability, or security issues. There was a request to update the action to a more current and actively maintained version:  
https://chatbotgang.slack.com/archives/CSA8JSWAZ/p1752469332304119

## 💡 How

- Updated the workflow to use chatbotgang/openai-pr-description@master instead of platisd/openai-pr-description@master.
- No API change or additional dependencies required—this is a direct substitution of the action.
- There should be no impact on existing workflows except improved reliability and maintainability.
- No feature flag or migration steps are necessary.

## Check list
- Asana Link:
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?