### PR TITLE
feat(tutorials): add tutorials on AI docs update and personal rules

### DIFF
--- a/.ai/prompt/chat_conclusion.prompt.md
+++ b/.ai/prompt/chat_conclusion.prompt.md
@@ -1,0 +1,137 @@
+---
+mode: agent
+---
+
+# Document Update Guidelines from Chat Context
+
+## Purpose
+This prompt guides AI agents on how to properly update documentation based on chat conversations, ensuring accuracy, appropriate scope, and clear separation between different types of documentation.
+
+## Document Types and Scope
+
+### 1. Development Conventions (`.cursor/rules/go.mdc`, `.cursor/rules/python.mdc`)
+**Purpose**: Technical patterns, architectural guidelines, and coding standards
+**Include**:
+- Architectural patterns (Clean Architecture, service patterns)
+- Naming conventions for code (classes, methods, models)
+- Code organization and structure
+- Testing patterns and standards
+- Error handling strategies
+- Performance optimization guidelines
+- Development workflow and methodology
+
+**Avoid**:
+- Specific business logic or domain rules
+- Implementation details of particular features
+- Overly specific examples that might not generalize
+- Business domain terminology explanations
+
+### 2. Knowledge Base (`python_src/kb`, `go_src/kb`)
+**Purpose**: Business domain knowledge, entities, and their relationships
+**Include**:
+- Business entities and their definitions
+- Entity relationships and dependencies
+- Business rules and constraints
+- Domain-specific terminology
+- Key operations and their business purposes
+- Data models and their business significance
+
+**Avoid**:
+- Technical implementation details
+- Code patterns and conventions
+- API endpoint specifications
+- Specific validation rules or technical constraints
+- Development workflow instructions
+
+## Update Principles
+
+### 1. Accuracy Over Completeness
+- Only document patterns that are actually established in the codebase
+- Avoid making absolute statements unless they are universally true
+- Use qualifying language ("often", "typically", "case-by-case") when appropriate
+- Verify claims against existing code before documenting
+
+### 2. Appropriate Abstraction Level
+- **Development Conventions**: Focus on reusable patterns and principles
+- **Knowledge Base**: Focus on business concepts and domain understanding
+- Avoid mixing technical implementation with business domain knowledge
+
+### 3. Flexibility Over Rigidity
+- Document patterns as guidelines, not absolute rules
+- Acknowledge when practices vary case-by-case
+- Avoid overly prescriptive language that might constrain future development
+- Provide context for when patterns should or shouldn't be applied
+
+### 4. Avoid Redundancy
+- Don't duplicate content between documents
+- Reference other documents when appropriate
+- Keep each document focused on its specific purpose
+- Remove or consolidate overlapping sections
+
+## Common Mistakes to Avoid
+
+### 1. Overgeneralization
+❌ "Always wrap data in `{"data": [...]}`"
+✅ "Consider consistent response formats for API endpoints"
+
+### 2. Too Specific Examples
+❌ Adding detailed sections about specific features (e.g., "Member Search Functionality")
+✅ Documenting general patterns that apply across features
+
+### 3. Wrong Document Placement
+❌ Putting technical patterns in the knowledge base
+❌ Putting business rules in development conventions
+✅ Clear separation based on document purpose
+
+### 4. Absolute Statements Without Context
+❌ "Domain Models: `{Action}{Domain}{Type}`"
+✅ "Domain Models: Case-by-case, can be simple entities or action-specific"
+
+## Update Process
+
+### 0. Initial Planning
+- **Update One Document at a Time**: Focus on completing one document fully before moving to the next
+- **Seek Clarification**: If you have any confusion or disagreement about what should be updated or how, ask the user for clarification before proceeding
+- **Confirm Approach**: When updating multiple documents, confirm the order and approach with the user
+
+### 1. Before Making Changes
+- Read the existing document to understand current structure and tone
+- Identify which type of document you're updating
+- Verify patterns exist in the codebase before documenting them
+- Check for potential redundancy with other documents
+
+### 2. While Making Changes
+- Maintain consistency with existing formatting and structure
+- Use clear, concise language appropriate for the document type
+- Provide context and reasoning for patterns when helpful
+- Include examples only when they illustrate broader principles
+
+### 3. After Making Changes
+- Review for accuracy and completeness
+- Ensure no redundancy with other documents
+- Verify the document maintains its focused purpose
+- Check that examples are representative, not overly specific
+
+## Key Questions to Ask
+
+Before documenting any pattern:
+1. **Is this pattern actually established in the codebase?**
+2. **Does this belong in this document type?**
+3. **Is this too specific to be generally useful?**
+4. **Am I making absolute statements that might not always be true?**
+5. **Does this duplicate information in another document?**
+6. **Would this constraint future development inappropriately?**
+
+## Success Criteria
+
+A well-updated document should:
+- ✅ Accurately reflect established patterns in the codebase
+- ✅ Maintain appropriate scope for its document type
+- ✅ Provide guidance without being overly prescriptive
+- ✅ Avoid redundancy with other documents
+- ✅ Use clear, professional language
+- ✅ Include context and reasoning for recommendations
+- ✅ Be useful for future development decisions
+
+## Remember
+The goal is to create documentation that helps developers understand and maintain consistency, not to constrain or over-specify implementation details. Focus on capturing the essence of good patterns while maintaining flexibility for future needs.

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/
 */bin/
 */cover.out
+.cursor/rules/personal.mdc
+.github/instructions/personal.instructions.md

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This workshop guides participants through **step-by-step agentic coding practice
 | 1       | Rewrite Brownfield     | Build Omnichannel Auto-Reply trigger logic with agentic coding              | 1h 20m         | [link](./tutorials/1_rewrite_brownfield.md) |
 | 2       | Extend Functions       | Extend Omnichannel Auto-Reply to support IG story-specific                  | 40m            | [link](./tutorials/2_extend_function.md) |
 | 3       | KB Extraction          | Extract knowledge from codebase and tribal knowledge for critical features  | 40m            | [link](./tutorials/3_kb_extraction.md) |
-| 4       | Sharpen your prompts   | Patterns for effective agent instructions                                   | 20m            | N/A |
+| 4       | Sharpen your prompts   | Patterns for effective agent instructions                                   | 20m            | [link1](./tutorials/4_chat_conclusion.md), [link2](./tutorials/5_personal_rules.md) |
 
 ## Codebase Outline
 

--- a/tutorials/4_chat_conclusion.md
+++ b/tutorials/4_chat_conclusion.md
@@ -1,0 +1,133 @@
+# Chat Conclusion
+
+Maintain accurate and valuable documentation with AI-powered updates.
+
+## Background
+
+As we've seen in previous tutorials, Knowledge Base (KB) and development conventions are critical for successful AI-assisted development. However, documentation easily becomes outdated, inaccurate, or cluttered without proper maintenance practices.
+
+The key challenges in documentation management include:
+1. **Document Type Confusion**: Mixing technical patterns with business domain knowledge
+2. **Accuracy Drift**: Documentation becoming outdated as code evolves
+3. **Overgeneralization**: Creating rigid rules from specific implementation details
+4. **Scope Creep**: Adding irrelevant or overly specific content
+
+Therefore, our strategic approach for documentation management is:
+1. Clearly distinguish between development conventions and knowledge base documentation
+2. Use AI-powered prompts to systematically update documentation based on development work
+3. Follow established principles to maintain accuracy and appropriate scope
+4. Regularly validate documentation against actual codebase patterns
+
+## Tutorials
+
+### 0. Pre-read given materials
+
+In this section, we focus on properly maintaining documentation after development work. The chat conclusion prompt ([chat_conclusion.prompt.md](./../.ai/prompt/chat_conclusion.prompt.md)) provides comprehensive guidelines for AI-driven documentation updates. Please review the prompt carefully to understand the update framework and principles before starting.
+
+### 1. Open existing chat from previous section
+
+After completing development work from previous tutorials (feature implementation, refactoring, or extension), return to the existing chat session where the work was performed.
+
+This step is critical because:
+- The AI has full context of what was implemented
+- The conversation history contains the specific patterns and decisions made
+- The AI can accurately assess what documentation needs updating based on the actual work done
+
+**Prerequisites:**
+- Completed Tutorial 1, 2, or 3 with substantial implementation work
+- Have the chat session open where development occurred
+- All relevant code files are still in context
+
+### 2. Use chat conclusion prompt
+
+Simply invoke the chat conclusion prompt to systematically update documentation based on the development work completed in the current session.
+
+Example:
+```
+@chat_conclusion.prompt.md
+
+Based on our development work in this session, please update the relevant documentation following the guidelines in the prompt.
+```
+
+The AI will:
+- Analyze the conversation history to identify patterns established
+- Determine which documentation needs updating (development conventions vs KB)
+- Ask clarifying questions if needed
+- Make focused, accurate updates without overgeneralization
+
+**Key Guidelines:**
+- Let the AI determine what needs updating based on the session context
+- Answer any clarifying questions thoroughly
+- Focus on one document type at a time when AI requests it
+
+### 3. Review and validate updates
+
+**Quality Assurance Process:**
+1. **Accuracy Check**: Verify that documented patterns actually exist in the codebase
+2. **Scope Validation**: Ensure content is appropriate for the document type
+3. **Redundancy Review**: Check for overlap with other documentation
+4. **Flexibility Test**: Confirm that guidance doesn't over-constrain future development
+
+**Review Checklist:**
+- [ ] Patterns are established in codebase, not one-off implementations
+- [ ] Content matches document type (technical vs. business)
+- [ ] No absolute statements without proper context
+- [ ] Examples illustrate broader principles, not specific features
+- [ ] Language is appropriately flexible ("often", "typically", "consider")
+- [ ] No redundancy with other documents
+
+### 4. Maintain documentation freshness
+
+**Sustainable Maintenance Practices:**
+- Update documentation when actively working on related features
+- Address gaps discovered by new team members immediately
+- Focus on high-impact corrections rather than comprehensive overhauls
+- Accept that some outdated content is normal and expected
+
+**Warning Signs for Priority Updates:**
+- Documentation actively misleads developers
+- New team members consistently struggle with documented patterns
+- AI frequently contradicts existing documentation
+- Patterns documented as "always" are violated in recent code
+
+**Team Integration:**
+- Include documentation updates in definition of done for features
+- Have code reviewers check for documentation impacts
+- Create lightweight processes for capturing new patterns during development
+- Share documentation update responsibilities across team members
+
+## Appendix
+
+### Documentation Anti-Patterns
+
+**1. Implementation Documentation in KB**
+❌ **Bad**: Detailed API endpoint specifications in business KB
+✅ **Good**: Business purpose and data flow in KB, technical details in dev conventions
+
+**2. Overgeneralization from Single Examples**
+❌ **Bad**: "Always wrap responses in `{data: []}`" based on one implementation
+✅ **Good**: "Consider consistent response formats" with context about when to apply
+
+**3. Absolute Rules Without Context**
+❌ **Bad**: "Domain models must follow `{Action}{Domain}{Type}` pattern"
+✅ **Good**: "Domain model naming varies case-by-case; simple entities vs. action-specific models"
+
+**4. Business Rules in Technical Documentation**
+❌ **Bad**: Specific trigger priority logic in coding conventions
+✅ **Good**: General priority handling patterns in conventions, specific business rules in KB
+
+### Success Metrics
+
+**Effective Documentation Should:**
+- Enable new team members to contribute productively within days
+- Allow AI to answer specific questions accurately using the docs
+- Reduce repeated questions about established patterns
+- Guide decision-making without constraining innovation
+- Stay relevant for months without updates (not days)
+
+**Warning Signs of Poor Documentation:**
+- Frequent contradictions between docs and actual code
+- New developers ignoring documentation and asking human experts instead
+- AI providing answers that conflict with documented patterns
+- Documentation requiring constant updates to stay accurate
+- Team members working around documented "rules" regularly

--- a/tutorials/5_personal_rules.md
+++ b/tutorials/5_personal_rules.md
@@ -1,0 +1,153 @@
+# Personal Rules for AI
+
+Build short, concrete rules that make AI fit your development habits and prevent common issues.
+
+## Background
+
+Even the most advanced AI can miss important preferences when rules are too verbose or buried in documentation. Personal rules with highest priority ensure AI consistently follows your specific development habits and avoids recurring mistakes.
+
+The key challenges with AI rules include:
+1. **Rule Fatigue**: Long rules get ignored or partially followed
+2. **Priority Confusion**: Important preferences get lost among general guidelines
+3. **Context Loss**: AI forgets specific habits during long conversations
+4. **Repetitive Issues**: Same mistakes keep happening despite corrections
+
+Therefore, our strategic approach for personal rules is:
+1. Create short, concrete rules with highest priority declaration
+2. Focus on recurring issues and strong personal preferences
+3. Use forced confirmation patterns for critical workflows
+4. Test and refine rules based on actual AI behavior
+
+## Tutorials
+
+### 1. Copy the example rules to target place
+
+Copy the following example rules to your AI assistant rules file:
+
+**For Cursor** (`.cursor/rules/personal.mdc`):
+
+```markdown
+---
+alwaysApply: true
+---
+
+## This instruction applies to all files in the repository.
+## This instruction has the highest priority over other instructions.
+
+- Never run migration commands like `python manage.py migrate`.
+- The only way of running test is `pytest {test_file}`.
+- Use `git --no-pager` to view large diffs without pagination issues.
+- Ignore the Makefile and prevent use of `make` commands.
+- Prevent useless comments like "fix typos", "update README", or what the change you do.
+- Prevent using `Any` as a type hint.
+- Ask problem 1 by 1, and try to provide 4 options for each question.
+```
+
+**For GitHub Copilot** (`.github/instructions/personal.instructions.md`):
+
+```markdown
+---
+applyTo: '**'
+---
+
+## This instruction applies to all files in the repository.
+## This instruction has the highest priority over other instructions.
+
+- Never run migration commands like `python manage.py migrate`.
+- The only way of running test is `pytest {test_file}`.
+- Use `git --no-pager` to view large diffs without pagination issues.
+- Ignore the Makefile and prevent use of `make` commands.
+- Prevent useless comments like "fix typos", "update README", or what the change you do.
+- Prevent using `Any` as a type hint.
+- Ask problem 1 by 1, and try to provide 4 options for each question.
+```
+
+**Customization Tips:**
+- Modify commands based on your tech stack (e.g., `npm test` instead of `pytest`)
+- Add your specific prohibited commands
+- Include your preferred communication style
+- Keep it under 15-20 rules total
+
+### 2. Ensure the rule will be applied automatically
+
+Make sure your personal rules are set up to apply to all new chat sessions automatically.
+
+**For Cursor IDE:**
+- Save the file as `.cursor/rules/personal.mdc` in your project root
+- Cursor will automatically load rules from this location
+- Rules apply to all new chats in this workspace
+
+**Verification:**
+- The file should be in the correct location: `.cursor/rules/personal.mdc`
+- File should start with the highest priority declaration
+- Check that Cursor recognizes the rules file (it should appear in workspace context)
+
+**Alternative Locations:**
+- Some setups may use `.cursorrules` or other rule file formats
+- Check your Cursor settings for the correct rules directory
+- Ensure the file extension is `.mdc` for Markdown cursor rules
+
+### 3. Open a new chat and ask AI to run test
+
+Start a completely new chat session to test if the personal rules are working correctly.
+
+**Test Commands:**
+```
+Run tests for the project
+```
+
+**Expected AI Behavior:**
+- AI should use `pytest {test_file}` format instead of other test commands
+- AI should ask what specific test file to run
+- AI should provide 4 options for how to proceed
+
+## Appendix
+
+### Effective Personal Rules Patterns
+
+**1. Command Restrictions**
+```markdown
+- Never run `make` commands - use direct commands instead
+- Use `poetry add` not `pip install` for dependencies
+- Always use `git --no-pager` for large diffs
+```
+
+**2. Development Workflow**
+```markdown
+- For new features:
+  1. Domain models first
+  2. Confirm with me
+  3. Service layer with mocks
+  4. Confirm with me
+  5. Repository implementation
+```
+
+**3. Communication Style**
+```markdown
+- Ask problems 1 by 1, provide 4 options for each question
+- No implementation details in responses unless asked
+- Always confirm before making destructive changes
+```
+
+**4. Code Preferences**
+```markdown
+- Use Pydantic models instead of dataclasses
+- Prefer absolute imports over relative imports
+- No `Any` type hints - use specific types
+```
+
+### Rule Effectiveness Checklist
+
+**Good Personal Rules:**
+- [ ] Start with highest priority declaration
+- [ ] Are specific and concrete with examples
+- [ ] Address actual recurring issues you face
+- [ ] Include forced confirmation for critical workflows
+- [ ] Can be referenced quickly (@personal.mdc)
+- [ ] Are short enough to be fully processed by AI
+
+**Warning Signs:**
+- Rules are longer than 15-20 lines
+- AI consistently ignores certain rules
+- Rules are vague or open to interpretation
+- You keep having to repeat the same corrections


### PR DESCRIPTION
## 🤔 Why

AI-assisted development is most effective when documentation is accurate, up-to-date, and tailored to the team's habits. However, teams often struggle with:
- Outdated or miscategorized documentation as the codebase evolves
- Unclear separation between technical conventions and business/domain knowledge
- AI assistants not following personal development preferences or repeatedly making the same mistakes

These issues slow down onboarding, increase cognitive load, and reduce trust in both documentation and AI tools.

## 💡 How

- **Added two comprehensive tutorials:**
  1. **AI Docs Update Tutorial:** Demonstrates how to use a dedicated prompt (`chat_conclusion.prompt.md`) to guide AI in updating documentation based on chat context, ensuring correct placement, scope, and accuracy of updates.
  2. **Personal Rules Tutorial:** Shows how to define and enforce personal AI assistant rules (e.g., `.cursor/rules/personal.mdc`), letting users encode high-priority preferences and recurring corrections for improved AI behavior.

- **Updated `.gitignore`:** Added user-specific AI rule file paths (`.cursor/rules/personal.mdc`, `.github/instructions/personal.instructions.md`) to prevent accidental commits of personal configurations.

- **README.md:** Linked the new tutorials in the workshop overview to improve discoverability.

**Benefits:**
- Provides clear, actionable workflows for keeping documentation fresh and well-organized using AI.
- Empowers users to proactively shape AI assistant behavior to fit their needs and prevent repeated issues.
- Reduces onboarding friction for new team members and increases the value of both documentation and AI tools.

**No breaking changes or new dependencies introduced.**

## Check list
- Asana Link: <!-- Asana Link-->
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?

---