### PR TITLE
chore(tooling): improve linting and testing setup

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -69,3 +69,5 @@ jobs:
       - name: Run pytest
         working-directory: python_src
         run: poetry run pytest
+        env:
+            PYTHONPATH: "."

--- a/python_src/Makefile
+++ b/python_src/Makefile
@@ -141,12 +141,12 @@ clean:
 fmt:
 	@echo "🔍 Running code linting..."
 	@if command -v poetry &> /dev/null; then \
-		echo "📝 Running black (code formatter)..."; \
-		poetry run black .; \
-		echo "🔧 Running isort (import sorter)..."; \
-		poetry run isort .; \
-		echo "🔎 Running pyright (type checker)..."; \
-		poetry run pyright; \
+		echo "📝 Running black (code formatter)..." && \
+		poetry run black . && \
+		echo "🔧 Running isort (import sorter)..." && \
+		poetry run isort . && \
+		echo "🔎 Running pyright (type checker)..." && \
+		poetry run pyright && \
 		echo "✅ All linting checks completed"; \
 	else \
 		echo "❌ Poetry not found in PATH. Please run 'make init' first."; \
@@ -157,7 +157,7 @@ fmt:
 test:
 	@echo "🧪 Running tests..."
 	@if command -v poetry &> /dev/null; then \
-		PYTHONPATH=. poetry run pytest -v --tb=short; \
+		PYTHONPATH=. poetry run pytest -v --tb=short && \
 		echo "✅ Tests completed"; \
 	else \
 		echo "❌ Poetry not found in PATH. Please run 'make init' first."; \

--- a/python_src/pyproject.toml
+++ b/python_src/pyproject.toml
@@ -33,22 +33,16 @@ freezegun = "^1.5.2"
 line-length = 120
 target-version = ['py312']
 skip-magic-trailing-comma = true
-#include = '''
-#(
-#  /(
-#      python_src
-#  )/
-#)
-#'''
 
 [tool.isort]
 profile = "black"
 line_length = 120
 atomic = true
-#src_paths = ["python_src"]
 
 [tool.pyright]
-#include = ["python_src"]
+exclude = [
+    "tests"
+]
 strictListInference = true
 strictSetInference = true
 # since the dictionary may contain various values, we disable the strict dictionary inference
@@ -64,12 +58,9 @@ reportDeprecated = true
 reportUnusedExpression = true
 
 [tool.pytest.ini_options]
-#pythonpath = [
-#    "python_src"
-#]
-#testpaths = [
-#    "tests"
-#]
+testpaths = [
+    "tests"
+]
 markers = [
     "unit",
 ]


### PR DESCRIPTION
## 🤔 Why

The current linting and testing setup has several issues that make development less robust and reliable:
- The `fmt` and `test` Makefile targets can pass even if one of the steps fails, due to use of `;` instead of `&&`.
- `pyright` type checks are run on the `tests` directory, which may contain test-specific or intentionally dynamic code not meant for strict type checking.
- The CI workflow does not explicitly set `PYTHONPATH` for `pytest`, which can lead to import errors or inconsistent test execution depending on environment.
- The `pytest` configuration in `pyproject.toml` contained redundant or commented-out `pythonpath` settings, which can be confusing and unnecessary.

## 💡 How

- Updated the `fmt` and `test` targets in the Makefile to chain commands with `&&`, ensuring that the workflow stops on the first error for more reliable linting and test runs.
- Updated `pyright` configuration to exclude the `tests` directory from type checking, focusing static analysis only on production code.
- Explicitly set `PYTHONPATH` in the GitHub Actions workflow and the Makefile for `pytest` runs, ensuring consistent import paths across different environments.
- Removed redundant or commented-out `pytest` `pythonpath` config from `pyproject.toml` to keep configuration clean and clear.

These changes make the linting and testing process fail-fast, more predictable, and easier to maintain, reducing the risk of missing errors or misconfigurations.

## Check list
- Asana Link: <!-- Asana Link -->
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?

---