### PR TITLE
docs(tutorials): clarify personal rules and Cursor Memory

### DIFF
--- a/tutorials/5_personal_rules.md
+++ b/tutorials/5_personal_rules.md
@@ -2,6 +2,8 @@
 
 Build short, concrete rules that make AI fit your development habits and prevent common issues.
 
+> **Note**: This feature is absolutely the same as Cursor Memory. Personal rules in Cursor IDE are implemented through the memory system, which stores your preferences and applies them consistently across all chat sessions. Whether you call it "personal rules," "memory," or "workspace rules," the underlying functionality is identical - it's Cursor's way of remembering and enforcing your development preferences automatically.
+
 ## Background
 
 Even the most advanced AI can miss important preferences when rules are too verbose or buried in documentation. Personal rules with highest priority ensure AI consistently follows your specific development habits and avoids recurring mistakes.


### PR DESCRIPTION
## 🤔 Why

Some users expressed confusion about the difference between "personal rules" and "Cursor Memory" in the documentation, leading to uncertainty about which feature to use and how they interact. This ambiguity could cause users to miss out on functionality or misuse features.

## 💡 How

- Added a clarifying note at the top of the **Personal Rules** tutorial to explicitly state that personal rules are functionally identical to Cursor Memory.
- The new note explains that both features are implemented through the same memory system, and the terminology differences are only superficial.
- This clarification should help prevent further user confusion and streamline the onboarding process for new users.

## Check list
- Asana Link: <!-- Asana Link-->
- [ ] Do you need a feature flag to protect this change?
- [ ] Do you need tests to verify this change?

---