### PR TITLE
chore(vscode): add ai prompt files setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
-.vscode/
 */bin/
 */cover.out
 .cursor/rules/personal.mdc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "chat.promptFilesLocations": {
+        ".ai/prompts": true
+    }
+}


### PR DESCRIPTION
## 🤔 Why

Previously, our repository ignored the `.vscode/` directory, preventing us from sharing useful workspace settings. As a result, developers may not have consistent configuration for locating AI prompt files, which can lead to confusion or misconfiguration when working with AI-assisted features in the project.

## 💡 How

- This PR unignores the `.vscode/` directory and adds a `.vscode/settings.json` file to the repository.
- The new setting, `"chat.promptFilesLocations": { ".ai/prompts": true }`, ensures that VS Code recognizes and uses the `.ai/prompts` directory for AI prompt files.
- This change enables a consistent development environment across all contributors, reducing onboarding friction and ensuring AI tooling works out-of-the-box.
- No new packages or feature flags are required.
- No API changes are introduced.

## Check list
- Asana Link: <!-- Asana Link-->
- [ ] Do you need a feature flag to protect this change?  
- [ ] Do you need tests to verify this change?
